### PR TITLE
Add regression tests for comment handling

### DIFF
--- a/tests/comment_macro_skip.cu
+++ b/tests/comment_macro_skip.cu
@@ -1,0 +1,9 @@
+/* comment_macro_skip.cu -- preprocessor comments stay opaque */
+
+#define COMMENT_MACRO 23 /* trailing body comment */
+
+/* COMMENT_MACRO should remain literal inside this block comment. */
+__global__ void comment_macro_skip(int *out)
+{
+    out[0] = COMMENT_MACRO;
+}

--- a/tests/comment_quotes.cu
+++ b/tests/comment_quotes.cu
@@ -1,0 +1,7 @@
+/* comment_quotes.cu -- block comments may contain quote characters */
+
+/* The kernel's first instruction is not here: ' " ` */
+__global__ void comment_quotes(int *out)
+{
+    out[0] = 1;
+}

--- a/tests/tphase.c
+++ b/tests/tphase.c
@@ -16,6 +16,25 @@ static void pha_pp(void)
 }
 TH_REG("phase", pha_pp)
 
+static void pha_pp_comment_opaque(void)
+{
+    int rc = th_run(BC_BIN " --pp tests/comment_macro_skip.cu", obuf, TH_BUFSZ);
+    CHEQ(rc, 0);
+    CHECK(strstr(obuf, "COMMENT_MACRO should remain literal") != NULL);
+    CHECK(strstr(obuf, "23 should remain literal") == NULL);
+    PASS();
+}
+TH_REG("phase", pha_pp_comment_opaque)
+
+static void pha_lex_comment_quotes(void)
+{
+    int rc = th_run(BC_BIN " --lex tests/comment_quotes.cu", obuf, TH_BUFSZ);
+    CHEQ(rc, 0);
+    CHECK(strstr(obuf, "0 error(s)") != NULL);
+    PASS();
+}
+TH_REG("phase", pha_lex_comment_quotes)
+
 /* ---- phase: parser (AST dump) ---- */
 
 static void pha_ast(void)


### PR DESCRIPTION
Covers #88 and #89.

## Summary
- add a preprocessor regression fixture proving macros remain literal inside `/* */` comments
- add a lexer regression fixture proving quote characters inside `/* */` comments do not start string or char literals
- register both cases in the phase test group

The current `master` behavior already passes these repros, so this PR intentionally adds coverage rather than changing compiler logic.

## Validation
- `make -j2`
- `./trunner --test pha_pp_comment_opaque`
- `./trunner --test pha_lex_comment_quotes`
- `git diff --check`

Note: `make test` builds and the two new tests pass, but the full suite exits nonzero on existing `pha_ast` / `pha_sema` failures against `tests/vector_add.cu`. Those commands also return 0 when run directly, so this appears unrelated to the new fixtures.