### PR TITLE
lower tl.where to select

### DIFF
--- a/src/triton/lower.c
+++ b/src/triton/lower.c
@@ -315,6 +315,26 @@ static int l_type_kind(const tn_lower_t *L, uint32_t type_idx)
     return L->bir->types[type_idx].kind;
 }
 
+static uint32_t l_tjoin(tn_lower_t *L, uint32_t a, uint32_t b)
+{
+    if (a == b) return a;
+    if ((a == L->t_i32 && b == L->t_f32) ||
+        (a == L->t_f32 && b == L->t_i32))
+        return L->t_f32;
+    return BIR_VAL_NONE;
+}
+
+static uint32_t l_cast(tn_lower_t *L, uint32_t v, uint32_t dst)
+{
+    uint32_t src = l_val_type(L, v);
+    if (src == dst) return v;
+    if (src != L->t_i32 || dst != L->t_f32)
+        return BIR_VAL_NONE;
+    uint32_t inst = l_emit(L, BIR_SITOFP, dst, 0);
+    l_op(L, inst, v);
+    return inst;
+}
+
 /* Map a Triton BinOp subcode onto the matching BIR opcode, choosing
  * integer or floating-point flavour based on the operand types. The
  * pointer-plus-int case is handled separately because it lowers to
@@ -751,6 +771,52 @@ static uint32_t l_intrinsic_call(tn_lower_t *L, uint32_t call_idx,
         uint32_t div = l_emit(L, BIR_SDIV, L->t_i32, 0);
         l_op(L, div, sum); l_op(L, div, b);
         return div;
+    }
+
+    case TN_TLI_WHERE: {
+        /* tl.where(cond, a, b) is the Triton spelling of a predicated
+         * elementwise select. Rank-1 tiles lower through the scalar lane
+         * model here; rank-2 fan-out belongs to the materialised tile path
+         * and is deliberately not smuggled into this scalar lowerer. */
+        uint32_t cn = l_pos_arg(L, call_idx, 0);
+        uint32_t tn = l_pos_arg(L, call_idx, 1);
+        uint32_t fn = l_pos_arg(L, call_idx, 2);
+        if (cn == 0 || tn == 0 || fn == 0) {
+            l_err(L, 95, l_tok(L, call_idx),
+                  "tl.where expects condition, true value, false value");
+            return BIR_VAL_NONE;
+        }
+
+        uint32_t cond = l_expr(L, cn);
+        if (cond == BIR_VAL_NONE) return BIR_VAL_NONE;
+        int ck = l_type_kind(L, l_val_type(L, cond));
+        if (ck != BIR_TYPE_INT) {
+            l_err(L, 95, l_tok(L, call_idx),
+                  "tl.where condition must lower to an integer/bool mask");
+            return BIR_VAL_NONE;
+        }
+
+        uint32_t tv = l_expr(L, tn);
+        uint32_t fv = l_expr(L, fn);
+        if (tv == BIR_VAL_NONE || fv == BIR_VAL_NONE) return BIR_VAL_NONE;
+
+        uint32_t tty = l_val_type(L, tv);
+        uint32_t fty = l_val_type(L, fv);
+        uint32_t sty = l_tjoin(L, tty, fty);
+        if (sty == BIR_VAL_NONE) {
+            l_err(L, 95, l_tok(L, call_idx),
+                  "tl.where value types not yet lowerable");
+            return BIR_VAL_NONE;
+        }
+        tv = l_cast(L, tv, sty);
+        fv = l_cast(L, fv, sty);
+        if (tv == BIR_VAL_NONE || fv == BIR_VAL_NONE) return BIR_VAL_NONE;
+
+        uint32_t inst = l_emit(L, BIR_SELECT, sty, 0);
+        l_op(L, inst, cond);
+        l_op(L, inst, tv);
+        l_op(L, inst, fv);
+        return inst;
     }
 
     case TN_TLI_EXP:     return l_exp_nat(L, call_idx);

--- a/tests/tri_where.py
+++ b/tests/tri_where.py
@@ -1,0 +1,12 @@
+# tri_where.py - tl.where conditional select lowering coverage.
+import triton
+import triton.language as tl
+
+@triton.jit
+def tri_where(a_ptr, b_ptr, out_ptr, BLOCK: tl.constexpr = 256):
+    pid = tl.program_id(axis=0)
+    offsets = pid * BLOCK + tl.arange(0, BLOCK)
+    a = tl.load(a_ptr + offsets)
+    b = tl.load(b_ptr + offsets)
+    out = tl.where(a > b, a, b)
+    tl.store(out_ptr + offsets, out)

--- a/tests/tri_where_bad_cond.py
+++ b/tests/tri_where_bad_cond.py
@@ -1,0 +1,7 @@
+# tri_where_bad_cond.py - tl.where rejects non-mask conditions.
+import triton
+import triton.language as tl
+
+@triton.jit
+def tri_where_bad_cond(a, b):
+    out = tl.where(1.0, a, b)

--- a/tests/tri_where_int.py
+++ b/tests/tri_where_int.py
@@ -1,0 +1,7 @@
+# tri_where_int.py - tl.where integer select lowering coverage.
+import triton
+import triton.language as tl
+
+@triton.jit
+def tri_where_int(a, b):
+    out = tl.where(a > b, 1, 0)

--- a/tests/tri_where_mixed.py
+++ b/tests/tri_where_mixed.py
@@ -1,0 +1,12 @@
+# tri_where_mixed.py - tl.where numeric promotion coverage.
+import triton
+import triton.language as tl
+
+@triton.jit
+def tri_where_mixed(a_ptr, b_ptr, out_ptr, BLOCK: tl.constexpr = 256):
+    pid = tl.program_id(axis=0)
+    offsets = pid * BLOCK + tl.arange(0, BLOCK)
+    a = tl.load(a_ptr + offsets)
+    b = tl.load(b_ptr + offsets)
+    out = tl.where(a > b, a, 0)
+    tl.store(out_ptr + offsets, out)

--- a/tests/ttriton.c
+++ b/tests/ttriton.c
@@ -327,6 +327,49 @@ static void tt_lower_math_intrinsics(void)
 }
 TH_REG("triton", tt_lower_math_intrinsics)
 
+static void tt_lower_where_select(void)
+{
+    int rc = tt_run("--triton --ir tests/tri_where.py");
+    CHEQ(rc, 0);
+    CHECK(strstr(obuf, "fcmp ") != NULL);
+    CHECK(strstr(obuf, "select f32") != NULL);
+    CHECK(strstr(obuf, "E095") == NULL);
+    PASS();
+}
+TH_REG("triton", tt_lower_where_select)
+
+static void tt_lower_where_mixed_promotes(void)
+{
+    int rc = tt_run("--triton --ir --no-cfold tests/tri_where_mixed.py");
+    CHEQ(rc, 0);
+    CHECK(strstr(obuf, "sitofp i32") != NULL);
+    CHECK(strstr(obuf, "select f32") != NULL);
+    CHECK(strstr(obuf, "E095") == NULL);
+    PASS();
+}
+TH_REG("triton", tt_lower_where_mixed_promotes)
+
+static void tt_lower_where_i32_select(void)
+{
+    int rc = tt_run("--triton --ir --no-dce tests/tri_where_int.py");
+    CHEQ(rc, 0);
+    CHECK(strstr(obuf, "icmp ") != NULL);
+    CHECK(strstr(obuf, "select i32") != NULL);
+    CHECK(strstr(obuf, "E095") == NULL);
+    PASS();
+}
+TH_REG("triton", tt_lower_where_i32_select)
+
+static void tt_lower_where_bad_cond(void)
+{
+    int rc = tt_run("--triton --ir tests/tri_where_bad_cond.py");
+    CHNE(rc, 0);
+    CHECK(strstr(obuf, "E095") != NULL);
+    CHECK(strstr(obuf, "condition must lower") != NULL);
+    PASS();
+}
+TH_REG("triton", tt_lower_where_bad_cond)
+
 /* ============================================================
  * Backend: AMD GFX11
  * ============================================================ */


### PR DESCRIPTION
Lower `tl.where` in the Triton frontend. Fixes issue #78.