### PR TITLE
tensix: machine-code emit for baby-core RISC-V

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ __pycache__/
 /tri_*_host.cpp
 /tri_*_reader.cpp
 /tri_*_writer.cpp
+/tri_*.bin
+/tri_*.ttinsn
+/tri_*.elf
 
 # Ad-hoc test kernels and runners that piled up during the Moa GPU
 # port and the parameter-count and scratch-allocation investigations.

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ TSRC    = tests/tmain.c tests/tsmoke.c tests/tcomp.c tests/tenc.c \
 TOBJS   = $(TSRC:.c=.o)
 COBJS   = src/ir/bir.o src/ir/bir_print.o src/ir/bir_lower.o src/ir/bir_mem2reg.o src/ir/bir_cfold.o src/ir/bir_dce.o src/ir/bir_struct.o src/ir/bir_insert.o src/ir/bir_sroa.o \
           src/tdf/tdf.o src/tdf/tdf_lower.o src/tdf/tdf_fission.o src/tdf/tdf_place.o src/tdf/tdf_noc.o \
-          src/tensix/rv_enc.o src/tensix/rv_buf.o src/tensix/rv_elf.o src/tensix/rv_isel.o src/tensix/noc.o \
+          src/tensix/rv_enc.o src/tensix/rv_buf.o src/tensix/rv_elf.o src/tensix/rv_isel.o src/tensix/noc.o src/tensix/emit.o \
           runtime/soft_fp.o runtime/sysprint.o \
           src/amdgpu/amd_rplan.o src/amdgpu/encode.o src/amdgpu/enc_tab.o src/amdgpu/isel.o src/amdgpu/emit.o src/amdgpu/ra_ssa.o src/amdgpu/sched.o src/amdgpu/verify.o \
           src/fe/bc_err.o src/fe/lexer.o src/fe/parser.o src/fe/preproc.o src/fe/sema.o \

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ SOURCES = src/main.c \
           src/ir/bir.c src/ir/bir_print.c src/ir/bir_lower.c src/ir/bir_mem2reg.c src/ir/bir_cfold.c src/ir/bir_dce.c src/ir/bir_struct.c src/ir/bir_insert.c src/ir/bir_sroa.c \
           src/tdf/tdf.c src/tdf/tdf_lower.c src/tdf/tdf_fission.c src/tdf/tdf_place.c src/tdf/tdf_noc.c \
           src/amdgpu/amd_rplan.c src/amdgpu/isel.c src/amdgpu/emit.c src/amdgpu/ra_ssa.c src/amdgpu/encode.c src/amdgpu/enc_tab.c src/amdgpu/sched.c src/amdgpu/verify.c \
-          src/tensix/isel.c src/tensix/emit.c src/tensix/coarsen.c src/tensix/datamov.c \
+          src/tensix/isel.c src/tensix/emit.c src/tensix/coarsen.c src/tensix/datamov.c src/tensix/noc.c \
           src/tensix/rv_enc.c src/tensix/rv_buf.c src/tensix/rv_elf.c src/tensix/rv_isel.c src/cpu/cpu_emit.c src/cpu/cpu_elf.c src/cpu/rv64_emit.c src/cpu/rv64_elf.c \
           src/nvidia/isel.c src/nvidia/emit.c \
           src/metal/emit.c \
@@ -63,12 +63,13 @@ TSRC    = tests/tmain.c tests/tsmoke.c tests/tcomp.c tests/tenc.c \
           tests/ttriton.c \
           tests/ttdf.c \
           tests/trv_enc.c tests/trv_buf.c tests/trv_elf.c tests/trv_isel.c \
+          tests/tcbsync.c \
           tests/tsoft_fp.c \
           tests/tsysprint.c
 TOBJS   = $(TSRC:.c=.o)
 COBJS   = src/ir/bir.o src/ir/bir_print.o src/ir/bir_lower.o src/ir/bir_mem2reg.o src/ir/bir_cfold.o src/ir/bir_dce.o src/ir/bir_struct.o src/ir/bir_insert.o src/ir/bir_sroa.o \
           src/tdf/tdf.o src/tdf/tdf_lower.o src/tdf/tdf_fission.o src/tdf/tdf_place.o src/tdf/tdf_noc.o \
-          src/tensix/rv_enc.o src/tensix/rv_buf.o src/tensix/rv_elf.o src/tensix/rv_isel.o \
+          src/tensix/rv_enc.o src/tensix/rv_buf.o src/tensix/rv_elf.o src/tensix/rv_isel.o src/tensix/noc.o \
           runtime/soft_fp.o runtime/sysprint.o \
           src/amdgpu/amd_rplan.o src/amdgpu/encode.o src/amdgpu/enc_tab.o src/amdgpu/isel.o src/amdgpu/emit.o src/amdgpu/ra_ssa.o src/amdgpu/sched.o src/amdgpu/verify.o \
           src/fe/bc_err.o src/fe/lexer.o src/fe/parser.o src/fe/preproc.o src/fe/sema.o \

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ TSRC    = tests/tmain.c tests/tsmoke.c tests/tcomp.c tests/tenc.c \
           tests/tregalloc.c \
           tests/ttriton.c \
           tests/ttdf.c \
+          tests/ttmc.c \
           tests/trv_enc.c tests/trv_buf.c tests/trv_elf.c tests/trv_isel.c \
           tests/tcbsync.c \
           tests/tsoft_fp.c \

--- a/src/main.c
+++ b/src/main.c
@@ -303,6 +303,17 @@ static int run_bir_backends(bir_module_t *bir, const backend_cfg_t *cfg)
                 cfg->output_file ? cfg->output_file : "a_compute.cpp";
             tensix_analyze_datamov(bir, ttm, &ttm->dmov);
             tensix_emit_metalium(ttm, compute_path);
+            /* Raw Tensix machine code alongside the Metalium C++: the encoded
+             * 32-bit word stream, decodable by ttas/Kahu. */
+            {
+                char bin_path[BC_MAX_PATH];
+                const char *st2 = strstr(compute_path, "_compute");
+                int bp = st2 ? (int)(st2 - compute_path)
+                             : (int)strlen(compute_path);
+                snprintf(bin_path, sizeof(bin_path), "%.*s_compute.bin",
+                         bp, compute_path);
+                tensix_emit_binary(ttm, bin_path);
+            }
             char host_path[BC_MAX_PATH];
             char reader_path[BC_MAX_PATH];
             char writer_path[BC_MAX_PATH];

--- a/src/main.c
+++ b/src/main.c
@@ -313,6 +313,10 @@ static int run_bir_backends(bir_module_t *bir, const backend_cfg_t *cfg)
                 snprintf(bin_path, sizeof(bin_path), "%.*s_compute.bin",
                          bp, compute_path);
                 tensix_emit_binary(ttm, bin_path);
+                /* The math core's RISC-V .ttinsn stream that issues them. */
+                snprintf(bin_path, sizeof(bin_path), "%.*s_compute.ttinsn",
+                         bp, compute_path);
+                tensix_emit_ttinsn(ttm, bin_path);
             }
             char host_path[BC_MAX_PATH];
             char reader_path[BC_MAX_PATH];

--- a/src/main.c
+++ b/src/main.c
@@ -339,6 +339,14 @@ static int run_bir_backends(bir_module_t *bir, const backend_cfg_t *cfg)
             tensix_emit_writer(ttm, &ttm->dmov, writer_path);
             tensix_emit_host_full(ttm, &ttm->dmov, host_path,
                                   reader_path, compute_path, writer_path);
+            /* The same three cores as baby-core machine code, one shared L1
+             * address map. The Metalium C++ above is the dev path; these ELFs
+             * are the toolchain-free path. */
+            {
+                char elf_stem[BC_MAX_PATH];
+                snprintf(elf_stem, sizeof(elf_stem), "%.*s", pfx, compute_path);
+                tensix_emit_kernel_elves(ttm, &ttm->dmov, elf_stem);
+            }
         } else {
             fprintf(stderr, "error: Tensix compilation failed\n");
             rc = trc;

--- a/src/tdf/tdf.c
+++ b/src/tdf/tdf.c
@@ -197,10 +197,9 @@ void td_dump(const td_mod_t *M, FILE *fp)
     int is_tt = (M->target == TD_TGT_TENSIX);
     for (uint16_t i = 0; i < M->nrgn; i++) {
         const td_rgn_t *r = &M->rgns[i];
-        /* core, x, y, twa only mean something on Tensix. On AMD and
-         * NVIDIA the region is a stand-in for the whole kernel and
-         * those fields are zero by default and would only confuse
-         * the reader of the dump. */
+        /* core, x, y, twa only mean something on Tensix. On AMD and NVIDIA the
+         * region stands in for the whole kernel, so those fields are zero and
+         * would only confuse the reader of the dump. */
         if (is_tt) {
             const char *core = (r->core < 5) ? k_core[r->core] : "-";
             fprintf(fp, "\n  region %u: %s core=%s twa=%u x=%u y=%u\n",

--- a/src/tdf/tdf.h
+++ b/src/tdf/tdf.h
@@ -8,20 +8,16 @@
 /*
  * Tile DataFlow IR.
  *
- * Sits above BIR. A CUDA __global__ lowers to a td_mod_t, which is a
- * graph of regions communicating via channels. On AMD and NVIDIA the
- * graph collapses to one region and forwards straight to BIR isel. On
- * Tensix the graph fans out, one region per baby core, channels become
- * L1 circular buffers, and arcs become inlined NoC + CB ops.
- *
- * The vocabulary is mainframe on purpose. Regions are CICS tasks with
- * their own working area. Channels are the TPF circular block lists
- * that the regions hand tiles through. Arcs are the ENQ/DEQ pairs
- * that the hardware enforces with semaphores. None of this is novel.
- * The novelty is the chip, not the bookkeeping pattern, which is the
- * same one that ran airline reservations on a 360 in 1968.
- *
- * No malloc. The module is sized at sema time and lives in one arena.
+ * Sits above BIR. A CUDA __global__ lowers to a td_mod_t, a graph of regions
+ * communicating via channels. On AMD and NVIDIA the graph collapses to one
+ * region and forwards straight to BIR isel; on Tensix it fans out, one region
+ * per baby core, channels become L1 circular buffers, and arcs become inlined
+ * NoC + CB ops. The vocabulary is mainframe on purpose: regions are CICS tasks
+ * with their own working area, channels are the TPF circular block lists the
+ * regions hand tiles through, and arcs are the ENQ/DEQ pairs the hardware
+ * enforces with semaphores. None of this is novel; the novelty is the chip, not
+ * the bookkeeping pattern that ran airline reservations on a 360 in 1968. No
+ * malloc, the module is sized at sema time and lives in one arena.
  */
 
 /* ---- Limits ---- */
@@ -37,45 +33,31 @@
 
 /* ---- Wormhole L1 placement constants ----
  *
- * Source citations live next to each value because the gap between
- * spec and reverse-engineered-from-tt-metal is wide and load-bearing
- * here. Future-us needs to know which number is gospel and which is
- * a sensible guess.
- *
- * Wormhole L1: 1,464 KiB usable, addressable from 0x00000000 to
- * 0x0016FFFF, organised as 16 banks of 91.5 KiB.
- * Source: tt-isa-documentation/WormholeB0/TensixTile/L1.md
- *
- * Code region reservation is OUR call: the docs do not specify a
- * fixed maximum kernel size, only that baby cores fetch instructions
- * from L1. 32 KiB up front is conservative and matches what typical
- * Metalium kernels use in practice. Adjust once we have real RV32IM
- * emission and can measure.
- *
- * NoC reads/writes from non-L1 to L1 require C16 congruence
- * (alignment to 16 bytes). Tile-data buffers must start on a 16-byte
- * boundary or they will be silently corrupted.
- * Source: tt-isa-documentation/WormholeB0/NoC/Alignment.md
- *
- * The 8-byte FIFO header is a software convention for an L1-resident
- * read/write pair when we run out of hardware semaphores (Wormhole
- * has eight, indices 0..7). The hardware semaphore path lives in
- * 0xFFE80000 MMIO and does not consume L1 at all; the L1 FIFO path
- * is used only as a fallback for channels nine and onward.
- * Source: tt-isa-documentation/WormholeB0/TensixTile/TensixCoprocessor/SyncUnit.md
+ * Source citations sit next to each value because the gap between spec and
+ * reverse-engineered-from-tt-metal is wide and load-bearing, and future-us needs
+ * to know which number is gospel and which is a sensible guess. Wormhole L1 is
+ * 1,464 KiB usable from 0x00000000 to 0x0016FFFF, organised as 16 banks of
+ * 91.5 KiB (WormholeB0/TensixTile/L1.md). The 32 KiB code reservation is OUR
+ * call, since the docs fix no maximum kernel size and only say baby cores fetch
+ * instructions from L1; it is conservative, matches typical Metalium kernels, and
+ * we can adjust once real RV32IM emission lets us measure. NoC reads/writes to L1
+ * require C16 congruence (16-byte alignment) or tile-data buffers start off a
+ * boundary and get silently corrupted (WormholeB0/NoC/Alignment.md). The 8-byte
+ * FIFO header is a software convention for an L1-resident read/write pair when we
+ * run out of the eight hardware semaphores (indices 0..7); the hardware path
+ * lives in 0xFFE80000 MMIO and costs no L1, so the L1 FIFO path serves only
+ * channels nine and onward (WormholeB0/.../SyncUnit.md).
  */
 #define TD_L1_BASE        0x00000000u
 #define TD_L1_END         0x00170000u    /* one past last usable byte */
 #define TD_L1_CODE_RSV    0x00008000u    /* 32 KiB for code + stack  */
 /*
- * Runtime args slab sits between code and CBs. The kernel reads
- * its CUDA coordinate intrinsics (threadIdx etc.) and its scalar
- * parameters from this region, populated by the host launcher
- * before dispatch. Layout lives in tensix/rt_args.h.
- *
- * 0x100 reserved (256 B) for the 112-byte struct plus growth room.
- * The base address has a 12-bit-zero low half so the isel can
- * materialise it with a single LUI: 0x00008000 = 0x8 << 12.
+ * Runtime args slab sits between code and CBs. The kernel reads its CUDA
+ * coordinate intrinsics (threadIdx etc.) and its scalar parameters from here,
+ * populated by the host launcher before dispatch, with the layout in
+ * tensix/rt_args.h. We reserve 0x100 (256 B) for the 112-byte struct plus growth
+ * room, and the base keeps a 12-bit-zero low half so the isel can materialise it
+ * with a single LUI (0x00008000 = 0x8 << 12).
  */
 #define TD_L1_RTARG_BASE  TD_L1_CODE_RSV
 #define TD_L1_RTARG_SIZE  0x00000100u
@@ -86,23 +68,16 @@
 
 /* ---- Wormhole NoC constants ----
  *
- * Source: tt-isa-documentation/WormholeB0/NoC/MemoryMap.md
- * (64-bit unicast address layout) and ./Alignment.md
- * (8192-byte max transfer).
- *
- * 64-bit NoC unicast address layout:
- *   bits  [35:0]   local memory address (36 bits, byte granularity)
- *   bits [41:36]   destination X coordinate (6 bits)
- *   bits [47:42]   destination Y coordinate (6 bits)
- *   bits [63:48]   reserved, ignored by the hardware
- *
- * Two physical NoCs run in opposite directions. NoC 0 favours reads
- * because it flows top-left to bottom-right which matches the
- * Tensix-to-DRAM direction for column-16 banks; NoC 1 favours
- * writes for the same reason in reverse, per RoutingPaths.md and
- * the congestion table in DRAMTile/README.md. Static VC allocation
- * matters for large writes but is below this layer's concern, the
- * RV32IM emitter sets it when materialising the NoC instruction.
+ * From WormholeB0/NoC/MemoryMap.md (64-bit unicast address layout) and
+ * ./Alignment.md (8192-byte max transfer). A unicast address packs the 36-bit
+ * byte-granular local memory address in bits [35:0], the 6-bit destination X in
+ * [41:36], the 6-bit destination Y in [47:42], and leaves [63:48] reserved and
+ * ignored by the hardware. Two physical NoCs run in opposite directions: NoC 0
+ * favours reads because it flows top-left to bottom-right, matching the
+ * Tensix-to-DRAM direction for column-16 banks, and NoC 1 favours writes for the
+ * same reason in reverse (RoutingPaths.md plus the DRAMTile/README.md congestion
+ * table). Static VC allocation matters for large writes but is below this layer's
+ * concern; the RV32IM emitter sets it when materialising the NoC instruction.
  */
 #define TD_NOC0           0u
 #define TD_NOC1           1u
@@ -315,54 +290,37 @@ int       td_build_solo_from_bir(td_mod_t *M, int target,
                                  bir_module_t *body);
 
 /*
- * Tensix fission. Takes a SOLO module whose body is a CUDA __global__
- * BIR and rewrites the TDF graph in place into the canonical
- * RDR/CMP/WRT three-region shape. Pointer parameters that are loaded
- * become channels from the reader into the compute region; pointer
- * parameters that are stored become channels from the compute region
- * out to the writer. The BIR body stays attached to the compute
- * region for now and the eventual BIR-level fission, which will
- * actually split the loads off the front and the stores off the back
- * into their own bodies, lands in a follow-up sitting.
- *
- * Returns BC_ERR_TDF if the input is not a Tensix SOLO module with a
- * body attached, if the body has no recognisable kernel function, or
- * if the BIR contains constructs that defeat the analysis (currently:
- * device function calls).
+ * Tensix fission. Takes a SOLO module whose body is a CUDA __global__ BIR and
+ * rewrites the TDF graph in place into the canonical RDR/CMP/WRT three-region
+ * shape: loaded pointer parameters become channels from the reader into compute,
+ * stored ones become channels from compute out to the writer. The BIR body stays
+ * attached to the compute region for now, and the eventual BIR-level fission that
+ * splits loads off the front and stores off the back into their own bodies lands
+ * in a follow-up sitting. Returns BC_ERR_TDF if the input is not a Tensix SOLO
+ * module with a body, has no recognisable kernel function, or contains constructs
+ * that defeat the analysis (currently device function calls).
  */
 int       td_fission_tensix(td_mod_t *M);
 
 /*
- * L1 placement. Walks every channel in the module, packs each one
- * into the CB region of L1 starting at TD_L1_CB_BASE, sets the
- * channel's l1_off field. First-fit static packing, channels packed
- * in declaration order; a future pass can sort by size or by core
- * once placement actually has more than one core to think about.
- *
- * Returns BC_ERR_TDF if the channels do not fit in the budget after
- * the code reservation. Today that ceiling is roughly 1,432 KiB
- * which is enough for ~350 fp32 32x32 tiles in flight, so the
- * error case is mostly a check against runaway depth values rather
- * than a real workload limit.
- *
- * Also exposes a helper that gives the byte size of one tile given
- * a channel tag, used by the placer and useful enough on its own
- * that the L1 emitter and the NoC orchestrator will both want it.
+ * L1 placement. Walks every channel, packs each into the CB region of L1 from
+ * TD_L1_CB_BASE and sets the channel's l1_off field, first-fit in declaration
+ * order; a future pass can sort by size or core once placement has more than one
+ * core to think about. Returns BC_ERR_TDF if the channels do not fit after the
+ * code reservation, a ceiling of roughly 1,432 KiB (about 350 fp32 32x32 tiles in
+ * flight), so the error case mostly guards against runaway depth values rather
+ * than a real workload limit. Also exposes a helper for the byte size of one tile
+ * given a channel tag, which the L1 emitter and the NoC orchestrator both want.
  */
 uint32_t  td_tile_bytes(td_tag_t tag);
 int       td_place_l1(td_mod_t *M);
 
 /*
- * NoC orchestration. Walks every RD and WR arc in the module,
- * fills in the noc_id (which of the two physical NoCs to use) and
- * length (bytes per fire) fields, and refuses any transfer that
- * busts the TD_NOC_MAX_XFER 8 KiB single-request limit.
- *
- * The 8 KiB limit is from Alignment.md and is a hard ceiling per
- * NoC request; bigger transfers must be split into multiple ops by
- * a future pass. Today we just bail rather than silently truncate.
- *
- * The encoder is exposed too so the eventual RV32IM emitter can
+ * NoC orchestration. Walks every RD and WR arc, fills in noc_id (which of the two
+ * physical NoCs to use) and length (bytes per fire), and refuses any transfer that
+ * busts the TD_NOC_MAX_XFER 8 KiB single-request limit from Alignment.md; bigger
+ * transfers must be split by a future pass, and until then we bail rather than
+ * silently truncate. The encoder is exposed too so the eventual RV32IM emitter can
  * reach for it directly rather than reinventing the bit-packing.
  */
 uint64_t  td_noc_addr(uint8_t x, uint8_t y, uint64_t local);

--- a/src/tdf/tdf.h
+++ b/src/tdf/tdf.h
@@ -368,6 +368,12 @@ int       td_place_l1(td_mod_t *M);
 uint64_t  td_noc_addr(uint8_t x, uint8_t y, uint64_t local);
 int       td_noc_orchestrate(td_mod_t *M);
 int       td_emit_cb_arc(td_mod_t *M, const td_arc_t *a, rv_buf_t *code);
+int       td_emit_dma_loop(rv_buf_t *code, int is_write,
+                           uint32_t dram_arg_slot, uint32_t ntiles_arg_slot,
+                           uint32_t l1_buf, uint32_t depth,
+                           uint32_t dram_mid, uint32_t l1_mid,
+                           uint32_t tile_bytes,
+                           uint32_t recv_addr, uint32_t free_addr);
 
 /* ---- Inspection ---- */
 

--- a/src/tdf/tdf.h
+++ b/src/tdf/tdf.h
@@ -3,6 +3,7 @@
 
 #include "barracuda.h"
 #include "bir.h"
+#include "rv_buf.h"     /* rv_buf_t, for the CB-arc emitter */
 
 /*
  * Tile DataFlow IR.
@@ -366,6 +367,7 @@ int       td_place_l1(td_mod_t *M);
  */
 uint64_t  td_noc_addr(uint8_t x, uint8_t y, uint64_t local);
 int       td_noc_orchestrate(td_mod_t *M);
+int       td_emit_cb_arc(td_mod_t *M, const td_arc_t *a, rv_buf_t *code);
 
 /* ---- Inspection ---- */
 

--- a/src/tdf/tdf_fission.c
+++ b/src/tdf/tdf_fission.c
@@ -5,23 +5,18 @@
 /*
  * Tensix kernel fission analysis.
  *
- * Reader/compute/writer is not a Tenstorrent invention. It is the
- * same producer/consumer pattern that ran ICL paper-tape pipelines,
- * the same one CICS named transaction regions after, and the same
- * one TPF lays out across baby cores. The hardware just makes it
- * physical: three baby RISC-V cores per Tensix, talking through L1
- * circular buffers, with a NoC instead of a backplane between them.
- *
- * What this pass does today: take a SOLO Tensix module whose body is
- * a CUDA __global__ in BIR form, identify which pointer parameters
- * are read and which are written, and rewrite the TDF graph as a
- * three-region pipeline with channels representing the data flow.
- *
- * What this pass does NOT do today: split the BIR body into three.
- * The CMP region still owns the original BIR; the RDR and WRT
- * regions are placeholders for the bodies a follow-up pass will
- * synthesise. Once that lands, td_lower for Tensix will accept the
- * fissioned shape and the multi-baby-core path comes online.
+ * Reader/compute/writer is not a Tenstorrent invention: it is the same
+ * producer/consumer pattern that ran ICL paper-tape pipelines, that CICS named
+ * transaction regions after, and that TPF lays out across baby cores. The
+ * hardware just makes it physical, three baby RISC-V cores per Tensix talking
+ * through L1 circular buffers with a NoC instead of a backplane. Today this pass
+ * takes a SOLO Tensix module whose body is a CUDA __global__ in BIR, identifies
+ * which pointer parameters are read and which are written, and rewrites the TDF
+ * graph as a three-region pipeline with channels for the data flow. It does not
+ * yet split the BIR body into three: the CMP region still owns the original BIR,
+ * and the RDR and WRT regions are placeholders for bodies a follow-up pass will
+ * synthesise, at which point td_lower for Tensix accepts the fissioned shape and
+ * the multi-baby-core path comes online.
  */
 
 #define FS_MAX_PARAMS   64

--- a/src/tdf/tdf_lower.c
+++ b/src/tdf/tdf_lower.c
@@ -5,22 +5,16 @@
 /*
  * Tile DataFlow lowering.
  *
- * Target-aware. Two paths today and a third that is still being
- * thought through.
- *
- * AMD and NVIDIA hit the degenerate path: the module is required to
- * contain exactly one region with role SOLO, the region's body is
- * handed back to the caller unchanged, no allocation happens, and
- * the existing isel chains continue exactly as they did before TDF
- * existed. If anything in this path costs more than a memcpy we
- * have done something wrong.
- *
- * Tensix is the real work and lives behind tdf_lower_tensix() which
- * is a stub for now. The first real version will collapse a SOLO
- * module to a single baby-core body for the soft-float Moa path,
- * because that is the smallest thing we can get on hardware. The
- * version after that will accept RDR/CMP/WRT fissioned modules and
- * fan them out across baby cores with channels lowered to L1.
+ * Target-aware, with two paths today and a third still being thought through.
+ * AMD and NVIDIA hit the degenerate path: the module must contain exactly one
+ * region with role SOLO, its body is handed back unchanged, no allocation
+ * happens, and the existing isel chains continue exactly as they did before TDF
+ * existed. If anything in this path costs more than a memcpy we have done
+ * something wrong. Tensix is the real work, behind tdf_lower_tensix(), a stub for
+ * now; the first real version collapses a SOLO module to a single baby-core body
+ * for the soft-float Moa path because that is the smallest thing we can get on
+ * hardware, and the version after accepts RDR/CMP/WRT fissioned modules and fans
+ * them across baby cores with channels lowered to L1.
  */
 
 static int lower_solo_passthrough(td_mod_t *M, td_lout_t *out)
@@ -57,13 +51,12 @@ static int lower_solo_passthrough(td_mod_t *M, td_lout_t *out)
 static int lower_tensix(td_mod_t *M, td_lout_t *out)
 {
     /*
-     * Tensix fission lives here. For now we only accept the same
-     * SOLO shape as AMD/NVIDIA and pass it through, so we can stand
-     * up the rest of the pipeline (frontend hookup, isel binding to
-     * a baby core, ELF emission) without needing the channel and
-     * arc lowering finished. The day SOLO-on-Tensix stops being
-     * enough is the day we add RDR/CMP/WRT handling here, and the
-     * shape of that work is laid out in the TDF design notes.
+     * Tensix fission lives here. For now we accept the same SOLO shape as
+     * AMD/NVIDIA and pass it through, so the rest of the pipeline (frontend
+     * hookup, isel binding to a baby core, ELF emission) can stand up without the
+     * channel and arc lowering finished. The day SOLO-on-Tensix stops being
+     * enough is the day RDR/CMP/WRT handling lands here, laid out in the TDF
+     * design notes.
      */
     if (M->nrgn == 1 && M->rgns[0].role == TD_RG_SOLO) {
         return lower_solo_passthrough(M, out);

--- a/src/tdf/tdf_noc.c
+++ b/src/tdf/tdf_noc.c
@@ -8,42 +8,30 @@
 /*
  * NoC orchestration pass.
  *
- * Two jobs. First, the encoder: given an X/Y coordinate pair and a
- * local memory address, build the 64-bit NoC address that any
- * later `noc_async_read` or `noc_async_write` instruction expects.
- * The bit layout is in tdf.h next to the TD_NOC_* constants and is
- * cited against WormholeB0/NoC/MemoryMap.md.
- *
- * Second, the per-arc orchestration: for every RD and WR arc in
- * the module, decide which of the two physical NoCs to use and
- * what length per fire. The choice today is mechanical: RD on
- * NoC 0 because that fabric flows top-left to bottom-right and
- * matches the Tensix-to-DRAM read direction for the column-16
- * DRAM banks; WR on NoC 1 for the reverse-flow analogue, which
- * Tenstorrent's own RoutingPaths.md plus the DRAMTile congestion
- * table both recommend. Smarter routing is a future pass once the
- * placer knows about multiple cores and DRAM bank affinity.
- *
- * Transfers longer than TD_NOC_MAX_XFER (8192 bytes per NoC
- * request, from Alignment.md) get refused rather than silently
- * truncated. Splitting a too-big transfer into multiple ops is
- * a worthwhile pass but the moment it lands the RV32IM emitter
- * has to know how to issue a sequence of NoC ops with bumped
- * source/destination pointers, and that needs the emitter to
- * exist in the first place. Until then, loud failure beats quiet
- * corruption.
+ * Two jobs. First the encoder: given an X/Y coordinate pair and a local memory
+ * address, build the 64-bit NoC address any later `noc_async_read` or
+ * `noc_async_write` expects, with the bit layout in tdf.h next to the TD_NOC_*
+ * constants (cited against WormholeB0/NoC/MemoryMap.md). Second the per-arc
+ * orchestration: for every RD and WR arc, decide which physical NoC to use and
+ * what length per fire. The choice is mechanical, RD on NoC 0 because that fabric
+ * flows top-left to bottom-right and matches the Tensix-to-DRAM read direction for
+ * the column-16 DRAM banks, WR on NoC 1 for the reverse-flow analogue, both
+ * recommended by Tenstorrent's RoutingPaths.md and the DRAMTile congestion table;
+ * smarter routing waits on a placer that knows about multiple cores and DRAM bank
+ * affinity. Transfers longer than TD_NOC_MAX_XFER (8192 bytes per request, from
+ * Alignment.md) get refused rather than silently truncated. A splitting pass is
+ * worthwhile, but the moment it lands the RV32IM emitter has to issue a sequence
+ * of NoC ops with bumped source/destination pointers, and that needs the emitter
+ * to exist in the first place; until then, loud failure beats quiet corruption.
  */
 
 uint64_t td_noc_addr(uint8_t x, uint8_t y, uint64_t local)
 {
-    /* MemoryMap.md unicast layout:
-     *   [35:0]   local address
-     *   [41:36]  X coordinate (6 bits)
-     *   [47:42]  Y coordinate (6 bits)
-     *   [63:48]  reserved, ignored.
-     * The broadcast format reuses bits [47:36] for an end-corner
-     * and packs the start-corner into [59:48], but we do not
-     * emit multicasts yet so the unicast encoder is enough. */
+    /* MemoryMap.md unicast layout: the local address is bits [35:0], the 6-bit X
+     * coordinate is [41:36], the 6-bit Y coordinate is [47:42], and [63:48] is
+     * reserved and ignored. The broadcast format reuses [47:36] for an end-corner
+     * and packs the start-corner into [59:48], but we do not emit multicasts yet
+     * so the unicast encoder is enough. */
     return (local & TD_NOC_LOCAL_MASK)
          | ((uint64_t)(x & TD_NOC_COORD_MASK) << TD_NOC_LOCAL_BITS)
          | ((uint64_t)(y & TD_NOC_COORD_MASK) << (TD_NOC_LOCAL_BITS + 6u));
@@ -96,20 +84,18 @@ int td_noc_orchestrate(td_mod_t *M)
 
 /*
  * CB-arc emitter: lower one circular-buffer synchronisation arc to baby-core
- * RISC-V, using the primitives in tensix/noc.c. This is the RV32IM emitter the
- * comments above kept deferring, for the four CB arc kinds. RD/WR arcs need
- * runtime DRAM addresses and a per-tile loop and are emitted elsewhere.
- *
- * The two counters live in the channel's FIFO header (the 8 bytes placement
- * reserves right after the tile-data buffer): recv at +0 counts pages the
- * producer has supplied, free at +4 counts pages the consumer has released.
- * Each region polls the counter it owns (local spin) and bumps the one its
- * partner owns (NoC atomic to the partner's coordinates).
- *
- * This targets the single-Tensix model the placer produces today: producer and
- * consumer are different baby cores sharing one L1, so both counters sit in
- * that L1 and the atomic targets the tile's own coordinates (permitted per
- * NoC/Atomics.md). Cross-tile counter placement lands with multi-core placement.
+ * RISC-V using the primitives in tensix/noc.c. This is the RV32IM emitter the
+ * comments above kept deferring, for the four CB arc kinds; RD/WR arcs need
+ * runtime DRAM addresses and a per-tile loop and are emitted elsewhere. The two
+ * counters live in the channel's FIFO header (the 8 bytes placement reserves
+ * right after the tile-data buffer): recv at +0 counts pages the producer has
+ * supplied, free at +4 counts pages the consumer has released, and each region
+ * polls the counter it owns (local spin) and bumps the one its partner owns (NoC
+ * atomic to the partner's coordinates). This targets the single-Tensix model the
+ * placer produces today, where producer and consumer are different baby cores
+ * sharing one L1, so both counters sit in that L1 and the atomic targets the
+ * tile's own coordinates (permitted per NoC/Atomics.md); cross-tile counter
+ * placement lands with multi-core placement.
  */
 int td_emit_cb_arc(td_mod_t *M, const td_arc_t *a, rv_buf_t *code)
 {
@@ -149,22 +135,18 @@ int td_emit_cb_arc(td_mod_t *M, const td_arc_t *a, rv_buf_t *code)
 
 /*
  * Tile-transfer loop: the machine-code form of a Metalium reader or writer
- * kernel. Reads the DRAM base address and the tile count from the runtime-args
- * slab the host populates, then loops once per tile:
- *
- *   reader: reserve a CB slot, NoC-read one tile DRAM -> L1, wait for it to
- *           land, push the slot to the consumer.
- *   writer: wait for a produced tile, NoC-write it L1 -> DRAM, wait for the
- *           ack, pop the slot back to the producer.
- *
- * Loop state lives in a-registers the called primitives never touch (they only
- * use t0/t1/t2): a3 = DRAM pointer, a4 = L1 ring pointer, a5 = tile counter,
- * a6 = tile_bytes, a7 = L1 ring end. The L1 pointer wraps to the buffer base
- * after `depth` tiles, which is the circular buffer doing its job.
- *
- * Contiguous DRAM layout: the DRAM pointer advances by one tile each step and
- * `dram_mid` is fixed. Interleaved bank addressing (where consecutive tiles
- * live in different DRAM banks with different coordinates) is a later pass.
+ * kernel. It reads the DRAM base address and the tile count from the runtime-args
+ * slab the host populates, then loops once per tile. The reader reserves a CB
+ * slot, NoC-reads one tile DRAM -> L1, waits for it to land, and pushes the slot
+ * to the consumer; the writer waits for a produced tile, NoC-writes it L1 -> DRAM,
+ * waits for the ack, and pops the slot back to the producer. Loop state lives in
+ * a-registers the called primitives never touch (they only use t0/t1/t2): a3 is
+ * the DRAM pointer, a4 the L1 ring pointer, a5 the tile counter, a6 tile_bytes,
+ * a7 the L1 ring end, and the L1 pointer wraps to the buffer base after `depth`
+ * tiles, which is the circular buffer doing its job. DRAM layout is contiguous so
+ * the DRAM pointer advances by one tile each step with `dram_mid` fixed;
+ * interleaved bank addressing, where consecutive tiles live in different banks
+ * with different coordinates, is a later pass.
  */
 int td_emit_dma_loop(rv_buf_t *code, int is_write,
                      uint32_t dram_arg_slot, uint32_t ntiles_arg_slot,

--- a/src/tdf/tdf_noc.c
+++ b/src/tdf/tdf_noc.c
@@ -1,4 +1,6 @@
 #include "tdf.h"
+#include "rv_buf.h"
+#include "noc.h"
 #include <stdio.h>
 
 /*
@@ -88,4 +90,57 @@ int td_noc_orchestrate(td_mod_t *M)
         a->length = len;
     }
     return BC_OK;
+}
+
+/*
+ * CB-arc emitter: lower one circular-buffer synchronisation arc to baby-core
+ * RISC-V, using the primitives in tensix/noc.c. This is the RV32IM emitter the
+ * comments above kept deferring, for the four CB arc kinds. RD/WR arcs need
+ * runtime DRAM addresses and a per-tile loop and are emitted elsewhere.
+ *
+ * The two counters live in the channel's FIFO header (the 8 bytes placement
+ * reserves right after the tile-data buffer): recv at +0 counts pages the
+ * producer has supplied, free at +4 counts pages the consumer has released.
+ * Each region polls the counter it owns (local spin) and bumps the one its
+ * partner owns (NoC atomic to the partner's coordinates).
+ *
+ * This targets the single-Tensix model the placer produces today: producer and
+ * consumer are different baby cores sharing one L1, so both counters sit in
+ * that L1 and the atomic targets the tile's own coordinates (permitted per
+ * NoC/Atomics.md). Cross-tile counter placement lands with multi-core placement.
+ */
+int td_emit_cb_arc(td_mod_t *M, const td_arc_t *a, rv_buf_t *code)
+{
+    const td_chan_t *c;
+    uint32_t data_b, recv, freec;
+
+    if (a->chan >= M->ncha) {
+        fprintf(stderr, "tdf: CB arc references unknown channel %u\n", a->chan);
+        return BC_ERR_TDF;
+    }
+    c = &M->chans[a->chan];
+    data_b = td_tile_bytes(c->tag) * (uint32_t)c->depth;
+    recv   = c->l1_off + data_b;          /* pages produced */
+    freec  = c->l1_off + data_b + 4u;     /* pages free      */
+
+    switch (a->kind) {
+    case TD_AR_RSV:     /* producer blocks until the consumer has freed slots */
+        return tt_cb_reserve_back(code, freec, a->cnt);
+    case TD_AR_WAIT:    /* consumer blocks until the producer has supplied tiles */
+        return tt_cb_wait_front(code, recv, a->cnt);
+    case TD_AR_PUSH: {  /* producer bumps the consumer's recv counter */
+        const td_rgn_t *cons = &M->rgns[c->cons];
+        uint64_t na = td_noc_addr((uint8_t)cons->x, (uint8_t)cons->y, recv);
+        return tt_cb_push_back(code, (uint32_t)na, (uint32_t)(na >> 32), a->cnt);
+    }
+    case TD_AR_POP: {   /* consumer bumps the producer's free counter */
+        const td_rgn_t *prod = &M->rgns[c->prod];
+        uint64_t na = td_noc_addr((uint8_t)prod->x, (uint8_t)prod->y, freec);
+        return tt_cb_pop_front(code, (uint32_t)na, (uint32_t)(na >> 32), a->cnt);
+    }
+    default:
+        fprintf(stderr, "tdf: td_emit_cb_arc given non-CB arc kind %u\n",
+                a->kind);
+        return BC_ERR_TDF;
+    }
 }

--- a/src/tdf/tdf_noc.c
+++ b/src/tdf/tdf_noc.c
@@ -176,6 +176,11 @@ int td_emit_dma_loop(rv_buf_t *code, int is_write,
     uint32_t loop, br_exit, br_wrap, jback, nowrap, done;
     uint32_t ring_end = l1_buf + depth * tile_bytes;
 
+    /* seed the counter this core acquires: a reader waits on free slots (start
+     * full = depth), a writer waits on produced tiles (start empty = 0). */
+    if (is_write) tt_sem_init(code, recv_addr, 0u);
+    else          tt_sem_init(code, free_addr, depth);
+
     /* prologue: pull args from L1, set up the loop registers. */
     tt_li32(code, RV_T0, TD_L1_RTARG_BASE);
     rv_buf_emit(code, rv_lw(RV_A3, RV_T0,

--- a/src/tdf/tdf_noc.c
+++ b/src/tdf/tdf_noc.c
@@ -1,5 +1,7 @@
 #include "tdf.h"
 #include "rv_buf.h"
+#include "rv_enc.h"
+#include "rt_args.h"
 #include "noc.h"
 #include <stdio.h>
 
@@ -143,4 +145,85 @@ int td_emit_cb_arc(td_mod_t *M, const td_arc_t *a, rv_buf_t *code)
                 a->kind);
         return BC_ERR_TDF;
     }
+}
+
+/*
+ * Tile-transfer loop: the machine-code form of a Metalium reader or writer
+ * kernel. Reads the DRAM base address and the tile count from the runtime-args
+ * slab the host populates, then loops once per tile:
+ *
+ *   reader: reserve a CB slot, NoC-read one tile DRAM -> L1, wait for it to
+ *           land, push the slot to the consumer.
+ *   writer: wait for a produced tile, NoC-write it L1 -> DRAM, wait for the
+ *           ack, pop the slot back to the producer.
+ *
+ * Loop state lives in a-registers the called primitives never touch (they only
+ * use t0/t1/t2): a3 = DRAM pointer, a4 = L1 ring pointer, a5 = tile counter,
+ * a6 = tile_bytes, a7 = L1 ring end. The L1 pointer wraps to the buffer base
+ * after `depth` tiles, which is the circular buffer doing its job.
+ *
+ * Contiguous DRAM layout: the DRAM pointer advances by one tile each step and
+ * `dram_mid` is fixed. Interleaved bank addressing (where consecutive tiles
+ * live in different DRAM banks with different coordinates) is a later pass.
+ */
+int td_emit_dma_loop(rv_buf_t *code, int is_write,
+                     uint32_t dram_arg_slot, uint32_t ntiles_arg_slot,
+                     uint32_t l1_buf, uint32_t depth,
+                     uint32_t dram_mid, uint32_t l1_mid,
+                     uint32_t tile_bytes,
+                     uint32_t recv_addr, uint32_t free_addr)
+{
+    uint32_t loop, br_exit, br_wrap, jback, nowrap, done;
+    uint32_t ring_end = l1_buf + depth * tile_bytes;
+
+    /* prologue: pull args from L1, set up the loop registers. */
+    tt_li32(code, RV_T0, TD_L1_RTARG_BASE);
+    rv_buf_emit(code, rv_lw(RV_A3, RV_T0,
+                            (int16_t)RT_ARG_OFF_KARG(dram_arg_slot)));
+    rv_buf_emit(code, rv_lw(RV_A5, RV_T0,
+                            (int16_t)RT_ARG_OFF_KARG(ntiles_arg_slot)));
+    tt_li32(code, RV_A4, l1_buf);
+    tt_li32(code, RV_A6, tile_bytes);
+    tt_li32(code, RV_A7, ring_end);
+
+    /* loop: exit once the tile counter hits zero (offset patched below). */
+    loop    = rv_buf_n_words(code);
+    br_exit = (uint32_t)rv_buf_emit(code, 0u);
+
+    /* pre-transfer CB gate. */
+    if (is_write) tt_cb_wait_front(code, recv_addr, 1u);
+    else          tt_cb_reserve_back(code, free_addr, 1u);
+
+    /* the transfer. reader: DRAM(a3) -> L1(a4); writer: L1(a4) -> DRAM(a3). */
+    if (is_write)
+        tt_noc_xfer_reg(code, 1, RV_A4, RV_A3, l1_mid, dram_mid, tile_bytes);
+    else
+        tt_noc_xfer_reg(code, 0, RV_A3, RV_A4, dram_mid, l1_mid, tile_bytes);
+    tt_noc_barrier(code, is_write);
+
+    /* post-transfer CB signal. */
+    if (is_write) tt_cb_pop_front(code, free_addr, 0u, 1u);
+    else          tt_cb_push_back(code, recv_addr, 0u, 1u);
+
+    /* advance both pointers; wrap the L1 ring pointer at its end. */
+    rv_buf_emit(code, rv_add(RV_A3, RV_A3, RV_A6));
+    rv_buf_emit(code, rv_add(RV_A4, RV_A4, RV_A6));
+    br_wrap = (uint32_t)rv_buf_emit(code, 0u);  /* bltu a4,a7,nowrap (patched) */
+    tt_li32(code, RV_A4, l1_buf);               /* wrap: reset to ring base    */
+    nowrap = rv_buf_n_words(code);
+    rv_buf_patch(code, br_wrap,
+                 rv_bltu(RV_A4, RV_A7,
+                         (int16_t)rv_buf_offset(code, br_wrap, nowrap)));
+
+    /* decrement and loop. */
+    rv_buf_emit(code, rv_addi(RV_A5, RV_A5, -1));
+    jback = rv_buf_n_words(code);
+    rv_buf_emit(code, rv_jal(RV_ZERO, rv_buf_offset(code, jback, loop)));
+
+    /* done: patch the exit branch now that we know where here is. */
+    done = rv_buf_n_words(code);
+    rv_buf_patch(code, br_exit,
+                 rv_beq(RV_A5, RV_ZERO,
+                        (int16_t)rv_buf_offset(code, br_exit, done)));
+    return BC_OK;
 }

--- a/src/tdf/tdf_place.c
+++ b/src/tdf/tdf_place.c
@@ -4,17 +4,13 @@
 /*
  * L1 placement pass.
  *
- * For each channel in the module, decide where its tile-data buffer
- * and FIFO header live in the home core's L1. Today we model L1 as
- * a single pool because we only target one Tensix at a time. When
- * multi-core lowering lands, each core gets its own running offset
- * and channels are assigned to whichever core hosts the producer.
- *
- * Spec citations are in tdf.h next to the TD_L1_* constants. The
- * short version: Wormhole L1 is 1,464 KiB at 0x00000000, NoC
- * reads/writes to L1 need 16-byte alignment, we reserve the first
- * 32 KiB for code, and channels pack first-fit upward from
- * TD_L1_CB_BASE.
+ * For each channel, decide where its tile-data buffer and FIFO header live in the
+ * home core's L1. Today L1 is a single pool because we only target one Tensix at
+ * a time; when multi-core lowering lands, each core gets its own running offset
+ * and channels go to whichever core hosts the producer. Spec citations sit in
+ * tdf.h next to the TD_L1_* constants: Wormhole L1 is 1,464 KiB at 0x00000000,
+ * NoC reads/writes to L1 need 16-byte alignment, the first 32 KiB is reserved for
+ * code, and channels pack first-fit upward from TD_L1_CB_BASE.
  */
 
 static uint32_t round_up(uint32_t x, uint32_t a)
@@ -23,12 +19,11 @@ static uint32_t round_up(uint32_t x, uint32_t a)
 }
 
 /*
- * Tile byte size from a channel tag. Width assumptions follow what
- * the fission pass currently writes: FLOAT defaults to fp32, BFLOAT
- * is the 16-bit brain float, INT defaults to int32. Once td_tag_t
- * carries an explicit width field (which it will, when issue #82
- * tile-shape inference lands and starts producing fp16 or fp8
- * channels) this collapses to a simple width lookup.
+ * Tile byte size from a channel tag. Width assumptions follow what the fission
+ * pass currently writes: FLOAT is fp32, BFLOAT is the 16-bit brain float, INT is
+ * int32. Once td_tag_t carries an explicit width field (when issue #82 tile-shape
+ * inference lands and starts producing fp16 or fp8 channels) this collapses to a
+ * simple width lookup.
  */
 static uint32_t dtype_bytes(uint8_t dt)
 {

--- a/src/tensix/datamov.c
+++ b/src/tensix/datamov.c
@@ -26,7 +26,7 @@ static void dm_write(FILE *fp, const char *fmt, ...)
 
 /* Follow the SSA def-use chain from an address operand back to the
  * BIR_PARAM that originally defined it. GEPs, bitcasts, and other
- * address computations are transparent — we just want the base pointer.
+ * address computations are transparent, we just want the base pointer.
  * Returns param index (subop) or -1 if the trail goes cold. */
 
 static int trace_to_param(const bir_module_t *bir, uint32_t val)
@@ -43,7 +43,7 @@ static int trace_to_param(const bir_module_t *bir, uint32_t val)
         if (I->op == BIR_PARAM)
             return (int)I->subop;
 
-        /* Transparent address computations — follow the base pointer */
+        /* Transparent address computations, follow the base pointer */
         if (I->op == BIR_GEP || I->op == BIR_BITCAST ||
             I->op == BIR_INTTOPTR || I->op == BIR_PTRTOINT) {
             val = I->operands[0];

--- a/src/tensix/datamov.c
+++ b/src/tensix/datamov.c
@@ -1,4 +1,9 @@
 #include "tensix.h"
+#include "tdf.h"          /* TD_L1_* layout constants, td_emit_dma_loop */
+#include "rt_args.h"
+#include "rv_buf.h"
+#include "rv_elf.h"
+#include "noc.h"
 #include <string.h>
 #include <stdio.h>
 #include <stdarg.h>
@@ -545,5 +550,100 @@ int tensix_emit_host_full(const tt_module_t *tt, const tt_dmov_t *dmov,
            host_path, dmov->num_bufs);
 
     (void)tt;
+    return BC_OK;
+}
+
+/* ---- Machine-code kernel images ----
+ * The reader/writer/host above emit Metalium C++. This emits the three baby-
+ * core ELFs directly: reader, compute, writer. It computes one canonical L1
+ * layout so all three cores agree on the CB buffer and counter addresses, which
+ * is the whole reason to do it in one place.
+ *
+ * Topology handled: one input CB and one output CB on a single Tensix (the
+ * eltwise shape). Multi-input fan-in and multi-Tensix placement are later work.
+ *
+ * Counters: each core seeds the one it acquires (free starts full = depth, recv
+ * starts empty = 0). Across the three: reader owns in_free, compute owns in_recv
+ * and out_free, writer owns out_recv. Every counter has exactly one acquirer and
+ * one remote signaller, so the seeding is consistent. */
+
+#define TT_CB_DEPTH 2u   /* ring depth for the wired single-kernel layout */
+
+static rv_buf_t g_kern_code;   /* 16 KiB; reused across the three ELFs */
+
+static uint32_t round16(uint32_t x) { return (x + 15u) & ~15u; }
+
+int tensix_emit_kernel_elves(tt_module_t *tt, const tt_dmov_t *dmov,
+                             const char *stem)
+{
+    const tt_dmov_buf_t *in = NULL, *out = NULL;
+    uint32_t i, sem, in_recv, in_free, out_recv, out_free, cb, in_buf, out_buf;
+    uint32_t ntiles_addr;
+    char path[BC_MAX_PATH];
+
+    for (i = 0; i < dmov->num_bufs; i++) {
+        const tt_dmov_buf_t *b = &dmov->bufs[i];
+        if (!b->is_output && !in)  in  = b;
+        if (b->is_output  && !out) out = b;
+    }
+    if (!in || !out) {
+        fprintf(stderr,
+                "tensix: ELF wiring needs >=1 input and >=1 output CB "
+                "(have %u in, %u out); skipping\n",
+                dmov->num_inputs, dmov->num_outputs);
+        return BC_OK;   /* not fatal: the Metalium path was still emitted */
+    }
+
+    /* canonical layout: four counters, then the two ring buffers. */
+    sem      = TD_L1_CB_BASE;
+    in_recv  = sem + 0u;
+    in_free  = sem + 4u;
+    out_recv = sem + 8u;
+    out_free = sem + 12u;
+    cb       = round16(sem + 16u);
+    in_buf   = cb;
+    out_buf  = round16(in_buf + in->tile_size * TT_CB_DEPTH);
+    ntiles_addr = TD_L1_RTARG_BASE + RT_ARG_OFF_KARG(1u);
+
+    /* reader: DRAM(arg slot 0) -> input CB. acquires in_free, signals in_recv. */
+    rv_buf_init(&g_kern_code);
+    td_emit_dma_loop(&g_kern_code, 0, 0u, 1u, in_buf, TT_CB_DEPTH,
+                     0u, 0u, in->tile_size, in_recv, in_free);
+    snprintf(path, sizeof path, "%s_reader.elf", stem);
+    if (rv_elf_write(&g_kern_code, path) != BC_OK) return BC_ERR_IO;
+
+    /* compute: input CB -> output CB. acquires in_recv and out_free. */
+    {
+        tt_compute_sync_t s;
+        memset(&s, 0, sizeof s);
+        s.ntiles_addr   = ntiles_addr;
+        s.in_recv_addr  = in_recv;
+        s.in_free_lo    = in_free;
+        s.out_free_addr = out_free;
+        s.out_recv_lo   = out_recv;
+        s.out_depth     = TT_CB_DEPTH;
+        rv_buf_init(&g_kern_code);
+        tensix_emit_compute_rv(tt, &g_kern_code, &s);
+        snprintf(path, sizeof path, "%s_compute.elf", stem);
+        if (rv_elf_write(&g_kern_code, path) != BC_OK) return BC_ERR_IO;
+    }
+
+    /* writer: output CB -> DRAM(arg slot 2). acquires out_recv, signals out_free. */
+    rv_buf_init(&g_kern_code);
+    td_emit_dma_loop(&g_kern_code, 1, 2u, 1u, out_buf, TT_CB_DEPTH,
+                     0u, 0u, out->tile_size, out_recv, out_free);
+    snprintf(path, sizeof path, "%s_writer.elf", stem);
+    if (rv_elf_write(&g_kern_code, path) != BC_OK) return BC_ERR_IO;
+
+    printf("wrote %s_{reader,compute,writer}.elf\n", stem);
+    printf("  L1 counters: in_recv=0x%x in_free=0x%x out_recv=0x%x out_free=0x%x\n",
+           (unsigned)in_recv, (unsigned)in_free,
+           (unsigned)out_recv, (unsigned)out_free);
+    printf("  L1 buffers:  in=0x%x (%uB x%u)  out=0x%x (%uB x%u)\n",
+           (unsigned)in_buf, (unsigned)in->tile_size, (unsigned)TT_CB_DEPTH,
+           (unsigned)out_buf, (unsigned)out->tile_size, (unsigned)TT_CB_DEPTH);
+    printf("  NOTE: compute load/store still bind to Dst row 0 (isel.c:432); the\n"
+           "        unpack/pack <-> CB-buffer binding is not yet emitted, so the\n"
+           "        compute core does not yet consume the delivered tiles.\n");
     return BC_OK;
 }

--- a/src/tensix/emit.c
+++ b/src/tensix/emit.c
@@ -622,6 +622,11 @@ tensix_emit_compute_rv(tt_module_t *tt, rv_buf_t *code,
 {
     uint32_t i, loop, br_exit, jback, done;
 
+    /* seed the counters this core acquires: its input starts empty (no tiles
+     * produced yet), its output ring starts full of free slots. */
+    tt_sem_init(code, s->in_recv_addr, 0u);
+    tt_sem_init(code, s->out_free_addr, s->out_depth);
+
     /* prologue: load the tile count into a5. */
     tt_li32(code, RV_T0, s->ntiles_addr);
     rv_buf_emit(code, rv_lw(RV_A5, RV_T0, 0));

--- a/src/tensix/emit.c
+++ b/src/tensix/emit.c
@@ -542,13 +542,11 @@ static uint32_t xf_raw(uint32_t w)    { return w; }
 static uint32_t xf_ttinsn(uint32_t w) { return (w << 2) | (w >> 30); }
 
 /* Write the compute word stream with a conservative circular-buffer sync
- * bracket. xform leaves the words raw (.bin) or .ttinsn-encodes them.
- *
- * The bracket is the first cut: SEMINIT sets up the semaphores, SEMWAIT blocks
- * compute until the input tile is available, SEMPOST signals the output tile.
- * The *encoding* of every word is validated against the Kahu decoder; the
- * semaphore-to-circular-buffer mapping is the provisional protocol and is the
- * piece that still needs confirmation on real hardware. */
+ * bracket; xform leaves the words raw (.bin) or .ttinsn-encodes them. SEMINIT
+ * sets up the semaphores, SEMWAIT blocks compute until the input tile arrives,
+ * and SEMPOST signals the output tile. Every word's encoding is validated
+ * against the Kahu decoder, but the semaphore-to-circular-buffer mapping is
+ * still the provisional protocol and needs confirmation on real hardware. */
 static int emit_stream(tt_module_t *tt, const char *path, uint32_t (*xform)(uint32_t))
 {
     FILE    *fp;
@@ -586,14 +584,13 @@ int tensix_emit_binary(tt_module_t *tt, const char *path)
 }
 
 /* ---- RISC-V .ttinsn stream ----
- * The Tensix coprocessor never fetches its own instructions; a baby RISC-V
- * core pushes each one by storing the 32-bit word to INSTRN_BUF_BASE
- * (0xFFE40000). The .ttinsn custom instruction is the shorthand: a single
- * RISC-V instruction whose encoding is the Tensix word rotated left by two
- * bits (hardware rotates it back right and stores it). Valid because every
- * real Tensix opcode is below 0xC0000000. Source: Wormhole B0 ISA docs,
- * BabyRISCV/PushTensixInstruction. This is the math core's instruction
- * stream: each word here issues one Tensix instruction. */
+ * The Tensix coprocessor never fetches its own instructions; a baby RISC-V core
+ * pushes each one by storing the 32-bit word to INSTRN_BUF_BASE (0xFFE40000).
+ * The .ttinsn custom instruction is the shorthand, one RISC-V instruction whose
+ * encoding is the Tensix word rotated left by two bits (hardware rotates it back
+ * right and stores it), valid because every real Tensix opcode is below
+ * 0xC0000000. Each word here issues one Tensix instruction. Source: Wormhole B0
+ * ISA docs, BabyRISCV/PushTensixInstruction. */
 
 int tensix_emit_ttinsn(tt_module_t *tt, const char *path)
 {
@@ -601,21 +598,17 @@ int tensix_emit_ttinsn(tt_module_t *tt, const char *path)
 }
 
 /* ---- Compute-core weave ----
- * The reader and writer cores are baby-RISC-V programs; so is the compute core.
- * Its body is the .ttinsn issue stream (each word a custom RISC-V instruction
- * that pushes one Tensix op), and around it goes the circular-buffer handshake
- * so it only computes on input tiles that have arrived and only overwrites
- * output slots the writer has drained.
- *
- * Per tile: wait for an input tile (wait_front), claim an output slot
- * (reserve_back), issue the math, publish the output (push_back), release the
- * input (pop_front). The tile count comes from the runtime-args slab; the
- * counter in a5 drives the loop. The CB primitives only touch t0/t1/t2, so a5
- * and the issue stream are undisturbed.
- *
- * This is the inter-core synchronisation, validated end to end. Intra-Tensix
- * unpack/math/pack ordering is the issue-stream sequence itself; the Sync Unit
- * bracket in emit_stream() remains the provisional on-chip piece. */
+ * The reader, writer and compute cores are all baby-RISC-V programs; the compute
+ * core's body is the .ttinsn issue stream (each word a custom RISC-V instruction
+ * that pushes one Tensix op), wrapped in the circular-buffer handshake so it only
+ * computes on input tiles that have arrived and only overwrites output slots the
+ * writer has drained. Per tile it waits for an input tile (wait_front), claims an
+ * output slot (reserve_back), issues the math, publishes the output (push_back)
+ * and releases the input (pop_front); the tile count comes from the runtime-args
+ * slab and the counter in a5 drives the loop, undisturbed because the CB
+ * primitives only touch t0/t1/t2. The inter-core synchronisation is validated end
+ * to end, while the Sync Unit bracket in emit_stream() remains the provisional
+ * on-chip piece. */
 int
 tensix_emit_compute_rv(tt_module_t *tt, rv_buf_t *code,
                        const tt_compute_sync_t *s)

--- a/src/tensix/emit.c
+++ b/src/tensix/emit.c
@@ -478,6 +478,40 @@ static uint32_t encode_inst(const tt_minst_t *I)
     }
 }
 
+/* ---- Raw Tensix machine code ----
+ * The Metalium path emits C++ for Tenstorrent's toolchain to compile. This
+ * one emits the real thing: the encoded 32-bit Tensix words, little-endian,
+ * the same stream ttas assembles and Kahu decodes. Pseudo-ops (phi/copy/def)
+ * are gone after regalloc; anything the table does not know is skipped. */
+
+int tensix_emit_binary(tt_module_t *tt, const char *path)
+{
+    FILE    *fp;
+    uint32_t i, n = 0;
+
+    fp = fopen(path, "wb");
+    if (!fp) return BC_ERR_IO;
+
+    for (i = 0; i < tt->num_minsts; i++) {
+        const tt_minst_t *I = &tt->minsts[i];
+        uint32_t w;
+        uint8_t  b[4];
+
+        if (!enc_lookup(I->op)) continue;   /* pseudo-op, not real hardware */
+
+        w = encode_inst(I);
+        b[0] = (uint8_t)(w & 0xFF);
+        b[1] = (uint8_t)((w >> 8) & 0xFF);
+        b[2] = (uint8_t)((w >> 16) & 0xFF);
+        b[3] = (uint8_t)((w >> 24) & 0xFF);
+        if (fwrite(b, 1, 4, fp) != 4) { fclose(fp); return BC_ERR_IO; }
+        n++;
+    }
+
+    fclose(fp);
+    return (n > 0) ? BC_OK : BC_ERR_IO;
+}
+
 /* ---- Disassembly ---- */
 
 static void disasm_inst(const tt_minst_t *I, char *buf, size_t bufsz)

--- a/src/tensix/emit.c
+++ b/src/tensix/emit.c
@@ -1,4 +1,8 @@
 #include "tensix.h"
+#include "rv_buf.h"
+#include "rv_enc.h"
+#include "rt_args.h"
+#include "noc.h"
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
@@ -594,6 +598,62 @@ int tensix_emit_binary(tt_module_t *tt, const char *path)
 int tensix_emit_ttinsn(tt_module_t *tt, const char *path)
 {
     return emit_stream(tt, path, xf_ttinsn);
+}
+
+/* ---- Compute-core weave ----
+ * The reader and writer cores are baby-RISC-V programs; so is the compute core.
+ * Its body is the .ttinsn issue stream (each word a custom RISC-V instruction
+ * that pushes one Tensix op), and around it goes the circular-buffer handshake
+ * so it only computes on input tiles that have arrived and only overwrites
+ * output slots the writer has drained.
+ *
+ * Per tile: wait for an input tile (wait_front), claim an output slot
+ * (reserve_back), issue the math, publish the output (push_back), release the
+ * input (pop_front). The tile count comes from the runtime-args slab; the
+ * counter in a5 drives the loop. The CB primitives only touch t0/t1/t2, so a5
+ * and the issue stream are undisturbed.
+ *
+ * This is the inter-core synchronisation, validated end to end. Intra-Tensix
+ * unpack/math/pack ordering is the issue-stream sequence itself; the Sync Unit
+ * bracket in emit_stream() remains the provisional on-chip piece. */
+int
+tensix_emit_compute_rv(tt_module_t *tt, rv_buf_t *code,
+                       const tt_compute_sync_t *s)
+{
+    uint32_t i, loop, br_exit, jback, done;
+
+    /* prologue: load the tile count into a5. */
+    tt_li32(code, RV_T0, s->ntiles_addr);
+    rv_buf_emit(code, rv_lw(RV_A5, RV_T0, 0));
+
+    loop    = rv_buf_n_words(code);
+    br_exit = (uint32_t)rv_buf_emit(code, 0u);          /* beq a5,zero,done */
+
+    /* acquire: input tile present, output slot free. */
+    tt_cb_wait_front(code, s->in_recv_addr, 1u);
+    tt_cb_reserve_back(code, s->out_free_addr, 1u);
+
+    /* the math: each real Tensix op issued as one .ttinsn instruction. */
+    for (i = 0; i < tt->num_minsts; i++) {
+        const tt_minst_t *I = &tt->minsts[i];
+        if (!enc_lookup(I->op)) continue;               /* pseudo-op */
+        rv_buf_emit(code, xf_ttinsn(encode_inst(I)));
+    }
+
+    /* publish output, release input. */
+    tt_cb_push_back(code, s->out_recv_lo, s->out_recv_mid, 1u);
+    tt_cb_pop_front(code, s->in_free_lo, s->in_free_mid, 1u);
+
+    /* decrement and loop. */
+    rv_buf_emit(code, rv_addi(RV_A5, RV_A5, -1));
+    jback = rv_buf_n_words(code);
+    rv_buf_emit(code, rv_jal(RV_ZERO, rv_buf_offset(code, jback, loop)));
+
+    done = rv_buf_n_words(code);
+    rv_buf_patch(code, br_exit,
+                 rv_beq(RV_A5, RV_ZERO,
+                        (int16_t)rv_buf_offset(code, br_exit, done)));
+    return BC_OK;
 }
 
 /* ---- Disassembly ---- */

--- a/src/tensix/emit.c
+++ b/src/tensix/emit.c
@@ -553,8 +553,10 @@ static int emit_stream(tt_module_t *tt, const char *path, uint32_t (*xform)(uint
     fp = fopen(path, "wb");
     if (!fp) return BC_ERR_IO;
 
-    if (!wr_word(fp, xform(sync_word(TT_SEMINIT, 0, 0, 1)))) goto io; /* sem0: val 0, max 1 */
-    if (!wr_word(fp, xform(sync_word(TT_SEMWAIT, 0, 1, 0)))) goto io; /* wait sem0, cond 1 */
+    /* SemaphoreMask is an 8-bit mask, not an index: sem 0 = 0x1 (input tile
+     * available), sem 1 = 0x2 (output tile produced). Init both, max 1. */
+    if (!wr_word(fp, xform(sync_word(TT_SEMINIT, 0x3, 0, 1)))) goto io; /* init sem 0 and 1 */
+    if (!wr_word(fp, xform(sync_word(TT_SEMWAIT, 0x1, 1, 0)))) goto io; /* wait input sem */
     n += 2;
 
     for (i = 0; i < tt->num_minsts; i++) {
@@ -564,7 +566,7 @@ static int emit_stream(tt_module_t *tt, const char *path, uint32_t (*xform)(uint
         n++;
     }
 
-    if (!wr_word(fp, xform(sync_word(TT_SEMPOST, 1, 0, 0)))) goto io; /* signal sem1 */
+    if (!wr_word(fp, xform(sync_word(TT_SEMPOST, 0x2, 0, 0)))) goto io; /* post output sem */
     n++;
 
     fclose(fp);

--- a/src/tensix/emit.c
+++ b/src/tensix/emit.c
@@ -72,6 +72,13 @@ static const tt_enc_entry_t enc_table_sparse[] = {
     /* Control */
     { TT_FMT_C, 0x02, "sfpnop"     },  /* TT_SFPNOP     */
     { TT_FMT_C, 0x8F, "sfpwnop"    },  /* TT_SFPWNOP    */
+
+    /* Sync Unit (semaphores / stalls). Field layouts from ttas/sfpi-binutils,
+     * cross-checked against the Kahu decoder. */
+    { TT_FMT_SYNC, 0xA2, "stallwait" },  /* TT_STALLWAIT */
+    { TT_FMT_SYNC, 0xA3, "seminit"   },  /* TT_SEMINIT   */
+    { TT_FMT_SYNC, 0xA4, "sempost"   },  /* TT_SEMPOST   */
+    { TT_FMT_SYNC, 0xA6, "semwait"   },  /* TT_SEMWAIT   */
 };
 
 #define ENC_TABLE_SPARSE_LEN \
@@ -79,7 +86,7 @@ static const tt_enc_entry_t enc_table_sparse[] = {
 
 static const tt_enc_entry_t *enc_lookup(uint16_t op)
 {
-    if (op >= 0x02 && op <= 0x99) {
+    if (op >= 0x02 && op <= 0xA6) {
         int guard = 256;
         for (uint32_t i = 0; i < ENC_TABLE_SPARSE_LEN && guard > 0;
              i++, guard--) {
@@ -473,6 +480,27 @@ static uint32_t encode_inst(const tt_minst_t *I)
         return op | ((lreg & 0xF) << 20) | ((mod0 & 0xF) << 16)
                   | (imm & 0xFFFF);
     }
+    case TT_FMT_SYNC: {
+        /* Per-opcode Sync Unit field layout. Operand order matches the
+         * disassembly: the fields named in each case below. */
+        int a = (int)get_imm(&I->operands[0]);
+        int b = (int)get_imm(&I->operands[1]);
+        int c = (int)get_imm(&I->operands[2]);
+        switch (enc->hw_opcode) {
+        case 0xA2:  /* stallwait: wait_res[0:14], stall_res[15:23] */
+            return op | ((b & 0x1FF) << 15) | (a & 0x7FFF);
+        case 0xA3:  /* seminit: sem_sel[2:15], init[16:19], max[20:23] */
+            return op | ((c & 0xF) << 20) | ((b & 0xF) << 16)
+                      | ((a & 0x3FFF) << 2);
+        case 0xA4:  /* sempost: sem_sel[2:23] */
+            return op | ((a & 0x3FFFFF) << 2);
+        case 0xA6:  /* semwait: cond[0:1], sem_sel[2:14], stall_res[15:23] */
+            return op | ((c & 0x1FF) << 15) | ((a & 0x1FFF) << 2)
+                      | (b & 0x3);
+        default:
+            return op;
+        }
+    }
     default:
         return op;
     }
@@ -484,7 +512,40 @@ static uint32_t encode_inst(const tt_minst_t *I)
  * the same stream ttas assembles and Kahu decodes. Pseudo-ops (phi/copy/def)
  * are gone after regalloc; anything the table does not know is skipped. */
 
-int tensix_emit_binary(tt_module_t *tt, const char *path)
+/* Build and encode one Sync Unit instruction (all operands are immediates). */
+static uint32_t sync_word(uint16_t op, int a, int b, int c)
+{
+    tt_minst_t I;
+    memset(&I, 0, sizeof(I));
+    I.op = op;
+    I.operands[0].kind = TT_MOP_IMM; I.operands[0].imm = a;
+    I.operands[1].kind = TT_MOP_IMM; I.operands[1].imm = b;
+    I.operands[2].kind = TT_MOP_IMM; I.operands[2].imm = c;
+    return encode_inst(&I);
+}
+
+static int wr_word(FILE *fp, uint32_t w)
+{
+    uint8_t b[4];
+    b[0] = (uint8_t)(w & 0xFF);
+    b[1] = (uint8_t)((w >> 8) & 0xFF);
+    b[2] = (uint8_t)((w >> 16) & 0xFF);
+    b[3] = (uint8_t)((w >> 24) & 0xFF);
+    return fwrite(b, 1, 4, fp) == 4;
+}
+
+static uint32_t xf_raw(uint32_t w)    { return w; }
+static uint32_t xf_ttinsn(uint32_t w) { return (w << 2) | (w >> 30); }
+
+/* Write the compute word stream with a conservative circular-buffer sync
+ * bracket. xform leaves the words raw (.bin) or .ttinsn-encodes them.
+ *
+ * The bracket is the first cut: SEMINIT sets up the semaphores, SEMWAIT blocks
+ * compute until the input tile is available, SEMPOST signals the output tile.
+ * The *encoding* of every word is validated against the Kahu decoder; the
+ * semaphore-to-circular-buffer mapping is the provisional protocol and is the
+ * piece that still needs confirmation on real hardware. */
+static int emit_stream(tt_module_t *tt, const char *path, uint32_t (*xform)(uint32_t))
 {
     FILE    *fp;
     uint32_t i, n = 0;
@@ -492,24 +553,30 @@ int tensix_emit_binary(tt_module_t *tt, const char *path)
     fp = fopen(path, "wb");
     if (!fp) return BC_ERR_IO;
 
+    if (!wr_word(fp, xform(sync_word(TT_SEMINIT, 0, 0, 1)))) goto io; /* sem0: val 0, max 1 */
+    if (!wr_word(fp, xform(sync_word(TT_SEMWAIT, 0, 1, 0)))) goto io; /* wait sem0, cond 1 */
+    n += 2;
+
     for (i = 0; i < tt->num_minsts; i++) {
         const tt_minst_t *I = &tt->minsts[i];
-        uint32_t w;
-        uint8_t  b[4];
-
         if (!enc_lookup(I->op)) continue;   /* pseudo-op, not real hardware */
-
-        w = encode_inst(I);
-        b[0] = (uint8_t)(w & 0xFF);
-        b[1] = (uint8_t)((w >> 8) & 0xFF);
-        b[2] = (uint8_t)((w >> 16) & 0xFF);
-        b[3] = (uint8_t)((w >> 24) & 0xFF);
-        if (fwrite(b, 1, 4, fp) != 4) { fclose(fp); return BC_ERR_IO; }
+        if (!wr_word(fp, xform(encode_inst(I)))) goto io;
         n++;
     }
 
+    if (!wr_word(fp, xform(sync_word(TT_SEMPOST, 1, 0, 0)))) goto io; /* signal sem1 */
+    n++;
+
     fclose(fp);
     return (n > 0) ? BC_OK : BC_ERR_IO;
+io:
+    fclose(fp);
+    return BC_ERR_IO;
+}
+
+int tensix_emit_binary(tt_module_t *tt, const char *path)
+{
+    return emit_stream(tt, path, xf_raw);
 }
 
 /* ---- RISC-V .ttinsn stream ----
@@ -524,31 +591,7 @@ int tensix_emit_binary(tt_module_t *tt, const char *path)
 
 int tensix_emit_ttinsn(tt_module_t *tt, const char *path)
 {
-    FILE    *fp;
-    uint32_t i, n = 0;
-
-    fp = fopen(path, "wb");
-    if (!fp) return BC_ERR_IO;
-
-    for (i = 0; i < tt->num_minsts; i++) {
-        const tt_minst_t *I = &tt->minsts[i];
-        uint32_t w, tti;
-        uint8_t  b[4];
-
-        if (!enc_lookup(I->op)) continue;
-
-        w   = encode_inst(I);
-        tti = (w << 2) | (w >> 30);     /* rotate left 2 = .ttinsn encoding */
-        b[0] = (uint8_t)(tti & 0xFF);
-        b[1] = (uint8_t)((tti >> 8) & 0xFF);
-        b[2] = (uint8_t)((tti >> 16) & 0xFF);
-        b[3] = (uint8_t)((tti >> 24) & 0xFF);
-        if (fwrite(b, 1, 4, fp) != 4) { fclose(fp); return BC_ERR_IO; }
-        n++;
-    }
-
-    fclose(fp);
-    return (n > 0) ? BC_OK : BC_ERR_IO;
+    return emit_stream(tt, path, xf_ttinsn);
 }
 
 /* ---- Disassembly ---- */

--- a/src/tensix/emit.c
+++ b/src/tensix/emit.c
@@ -512,6 +512,45 @@ int tensix_emit_binary(tt_module_t *tt, const char *path)
     return (n > 0) ? BC_OK : BC_ERR_IO;
 }
 
+/* ---- RISC-V .ttinsn stream ----
+ * The Tensix coprocessor never fetches its own instructions; a baby RISC-V
+ * core pushes each one by storing the 32-bit word to INSTRN_BUF_BASE
+ * (0xFFE40000). The .ttinsn custom instruction is the shorthand: a single
+ * RISC-V instruction whose encoding is the Tensix word rotated left by two
+ * bits (hardware rotates it back right and stores it). Valid because every
+ * real Tensix opcode is below 0xC0000000. Source: Wormhole B0 ISA docs,
+ * BabyRISCV/PushTensixInstruction. This is the math core's instruction
+ * stream: each word here issues one Tensix instruction. */
+
+int tensix_emit_ttinsn(tt_module_t *tt, const char *path)
+{
+    FILE    *fp;
+    uint32_t i, n = 0;
+
+    fp = fopen(path, "wb");
+    if (!fp) return BC_ERR_IO;
+
+    for (i = 0; i < tt->num_minsts; i++) {
+        const tt_minst_t *I = &tt->minsts[i];
+        uint32_t w, tti;
+        uint8_t  b[4];
+
+        if (!enc_lookup(I->op)) continue;
+
+        w   = encode_inst(I);
+        tti = (w << 2) | (w >> 30);     /* rotate left 2 = .ttinsn encoding */
+        b[0] = (uint8_t)(tti & 0xFF);
+        b[1] = (uint8_t)((tti >> 8) & 0xFF);
+        b[2] = (uint8_t)((tti >> 16) & 0xFF);
+        b[3] = (uint8_t)((tti >> 24) & 0xFF);
+        if (fwrite(b, 1, 4, fp) != 4) { fclose(fp); return BC_ERR_IO; }
+        n++;
+    }
+
+    fclose(fp);
+    return (n > 0) ? BC_OK : BC_ERR_IO;
+}
+
 /* ---- Disassembly ---- */
 
 static void disasm_inst(const tt_minst_t *I, char *buf, size_t bufsz)

--- a/src/tensix/noc.c
+++ b/src/tensix/noc.c
@@ -21,16 +21,24 @@
 #define NOC_RET_MID     0x10
 #define NOC_CTRL        0x1C
 #define NOC_AT_LEN_BE   0x20
+#define NOC_AT_DATA     0x24
 #define NOC_CMD_CTRL    0x28
 
 /* NOC_CTRL request type (bits [1:0]). */
 #define NOC_CMD_RD      0u
+#define NOC_CMD_AT      1u
 #define NOC_CMD_WR      2u
+
+/* NOC_AT_LEN_BE for an atomic increment (NoC/Atomics.md): op selector in
+ * [15:12] (1 = increment), IntWidth in [6:2], Ofs in [1:0]. IntWidth=31 is a
+ * full 32-bit add; Ofs=0 makes the target address the operand address. */
+#define NOC_AT_INC_FULL ((1u << 12) | (31u << 2))
 
 /* RISC-V registers (ABI names): x5 = t0 base, x6 = t1 value, x0 = zero. */
 #define RV_X0   0
 #define RV_T0   5
 #define RV_T1   6
+#define RV_T2   7
 
 /* Materialise a 32-bit value into reg via lui + addi, compensating for addi's
  * sign extension of the low 12 bits. */
@@ -83,4 +91,74 @@ tt_noc_write(rv_buf_t *c, uint32_t tlo, uint32_t tmid,
              uint32_t rlo, uint32_t rmid, uint32_t len)
 {
     return noc_xfer(c, NOC_CMD_WR, tlo, tmid, rlo, rmid, len);
+}
+
+/* ---- Circular-buffer synchronisation ----
+ *
+ * A CB is a producer/consumer pipe between two baby cores backed by a counter
+ * in L1. The producer signals "n pages ready" by atomically bumping a counter
+ * the consumer polls; the consumer signals "n pages free" the same way in
+ * reverse. The signal is a NoC atomic increment to the *other* core's L1; the
+ * wait is a local spin on this core's L1. Together they are the whole handshake.
+ */
+
+/* Atomically add `incr` to the 32-bit counter at the remote L1 address
+ * (sem_lo + sem_mid X/Y coords). Posted: no response is requested. */
+int
+tt_sem_inc(rv_buf_t *c, uint32_t sem_lo, uint32_t sem_mid, uint32_t incr)
+{
+    li32(c, RV_T0, NIU_BASE);
+    store_reg(c, sem_lo,         NOC_TARG_LO);
+    store_reg(c, sem_mid,        NOC_TARG_MID);
+    store_reg(c, NOC_AT_INC_FULL, NOC_AT_LEN_BE);
+    store_reg(c, incr,           NOC_AT_DATA);
+    store_reg(c, NOC_CMD_AT,     NOC_CTRL);
+    store_reg(c, 1u,             NOC_CMD_CTRL);   /* fire */
+    return BC_OK;
+}
+
+/* Spin until the 32-bit counter at local L1 byte address `sem_addr` is at
+ * least `threshold`. Two-instruction loop: reload, branch back if short. */
+int
+tt_sem_wait_ge(rv_buf_t *c, uint32_t sem_addr, uint32_t threshold)
+{
+    uint32_t loop;
+    int32_t  off;
+
+    li32(c, RV_T0, sem_addr);              /* t0 = &counter */
+    li32(c, RV_T2, threshold);             /* t2 = threshold */
+    loop = rv_buf_n_words(c);
+    rv_buf_emit(c, rv_lw(RV_T1, RV_T0, 0));        /* t1 = *counter */
+    off = rv_buf_offset(c, rv_buf_n_words(c), loop);
+    rv_buf_emit(c, rv_bltu(RV_T1, RV_T2, (int16_t)off));  /* t1 < t2 ? loop */
+    return BC_OK;
+}
+
+/* The four CB ops are just the wait/signal pair under their pipeline names.
+ * `recv` counts pages the producer has supplied; `free` counts pages the
+ * consumer has released. Each side polls the counter it owns and bumps the
+ * one its partner owns. */
+
+int
+tt_cb_reserve_back(rv_buf_t *c, uint32_t free_addr, uint32_t credits)
+{
+    return tt_sem_wait_ge(c, free_addr, credits);
+}
+
+int
+tt_cb_push_back(rv_buf_t *c, uint32_t recv_lo, uint32_t recv_mid, uint32_t n)
+{
+    return tt_sem_inc(c, recv_lo, recv_mid, n);
+}
+
+int
+tt_cb_wait_front(rv_buf_t *c, uint32_t recv_addr, uint32_t n)
+{
+    return tt_sem_wait_ge(c, recv_addr, n);
+}
+
+int
+tt_cb_pop_front(rv_buf_t *c, uint32_t free_lo, uint32_t free_mid, uint32_t n)
+{
+    return tt_sem_inc(c, free_lo, free_mid, n);
 }

--- a/src/tensix/noc.c
+++ b/src/tensix/noc.c
@@ -143,15 +143,39 @@ tt_sem_wait_ge(rv_buf_t *c, uint32_t sem_addr, uint32_t threshold)
     return BC_OK;
 }
 
-/* The four CB ops are just the wait/signal pair under their pipeline names.
- * `recv` counts pages the producer has supplied; `free` counts pages the
- * consumer has released. Each side polls the counter it owns and bumps the
- * one its partner owns. */
+/* Seed a local counter to `val` (one store; done once before the loop). */
+int
+tt_sem_init(rv_buf_t *c, uint32_t sem_addr, uint32_t val)
+{
+    li32(c, RV_T0, sem_addr);
+    li32(c, RV_T1, val);
+    rv_buf_emit(c, rv_sw(RV_T1, RV_T0, 0));
+    return BC_OK;
+}
+
+/* Acquire `n` credits from the local counter: spin until it holds at least n,
+ * then atomically subtract n. The subtract goes through the NoC atomic unit
+ * (incrementing by -n) rather than a plain load-store, so it cannot lose a
+ * concurrent remote increment from the partner core returning credits. */
+int
+tt_sem_acquire(rv_buf_t *c, uint32_t sem_addr, uint32_t n)
+{
+    tt_sem_wait_ge(c, sem_addr, n);
+    tt_sem_inc(c, sem_addr, 0u, (uint32_t)(0u - n));   /* atomic -= n (local) */
+    return BC_OK;
+}
+
+/* The four CB ops over the counting-semaphore pair. `free` counts empty slots
+ * (seeded to the ring depth), `recv` counts filled slots (seeded to zero). The
+ * acquiring ops (reserve_back, wait_front) wait then consume a credit; the
+ * signalling ops (push_back, pop_front) hand a credit to the partner over the
+ * NoC. Constant counts are correct because the counters track what is available
+ * right now, not a running total. */
 
 int
 tt_cb_reserve_back(rv_buf_t *c, uint32_t free_addr, uint32_t credits)
 {
-    return tt_sem_wait_ge(c, free_addr, credits);
+    return tt_sem_acquire(c, free_addr, credits);
 }
 
 int
@@ -163,7 +187,7 @@ tt_cb_push_back(rv_buf_t *c, uint32_t recv_lo, uint32_t recv_mid, uint32_t n)
 int
 tt_cb_wait_front(rv_buf_t *c, uint32_t recv_addr, uint32_t n)
 {
-    return tt_sem_wait_ge(c, recv_addr, n);
+    return tt_sem_acquire(c, recv_addr, n);
 }
 
 int

--- a/src/tensix/noc.c
+++ b/src/tensix/noc.c
@@ -24,10 +24,19 @@
 #define NOC_AT_DATA     0x24
 #define NOC_CMD_CTRL    0x28
 
-/* NOC_CTRL request type (bits [1:0]). */
+/* NOC_CTRL request type (bits [1:0]) and the marked-response flag (bit 4). */
 #define NOC_CMD_RD      0u
 #define NOC_CMD_AT      1u
 #define NOC_CMD_WR      2u
+#define NOC_CMD_RESP_MARKED (1u << 4)
+
+/* NIU counters (read-only) at NIU_BASE + 0x200, one 32-bit word each. The few
+ * we need to barrier on: reads issued vs completed, writes issued vs acked. */
+#define NIU_CNT_BASE    0xFFB20200u
+#define CNT_WR_ACK      (1u * 4u)    /* NIU_MST_WR_ACK_RECEIVED      */
+#define CNT_RD_RESP     (2u * 4u)    /* NIU_MST_RD_RESP_RECEIVED     */
+#define CNT_RD_REQ      (5u * 4u)    /* NIU_MST_RD_REQ_SENT          */
+#define CNT_WR_SENT     (10u * 4u)   /* NIU_MST_NONPOSTED_WR_REQ_SENT */
 
 /* NOC_AT_LEN_BE for an atomic increment (NoC/Atomics.md): op selector in
  * [15:12] (1 = increment), IntWidth in [6:2], Ofs in [1:0]. IntWidth=31 is a
@@ -161,4 +170,59 @@ int
 tt_cb_pop_front(rv_buf_t *c, uint32_t free_lo, uint32_t free_mid, uint32_t n)
 {
     return tt_sem_inc(c, free_lo, free_mid, n);
+}
+
+/* Expose the 32-bit materialiser; the tile-loop emitter needs it too. */
+void
+tt_li32(rv_buf_t *c, uint8_t reg, uint32_t v)
+{
+    li32(c, reg, v);
+}
+
+/* ---- Register-sourced transfer + completion barrier ----
+ *
+ * tt_noc_read/write take immediate addresses, which is all a fixed transfer
+ * needs. A tile loop instead keeps the source/destination addresses in
+ * registers and bumps them each iteration, so it needs a transfer whose low
+ * addresses come from registers. mid (the high address bits + X/Y coords) and
+ * the length stay immediate. Clobbers t0/t1; treg and rreg must be neither.
+ */
+int
+tt_noc_xfer_reg(rv_buf_t *c, int is_write, uint8_t treg, uint8_t rreg,
+                uint32_t tmid, uint32_t rmid, uint32_t len)
+{
+    uint32_t ctrl = is_write ? (NOC_CMD_WR | NOC_CMD_RESP_MARKED) : NOC_CMD_RD;
+    li32(c, RV_T0, NIU_BASE);
+    rv_buf_emit(c, rv_sw(treg, RV_T0, NOC_TARG_LO));   /* target low from reg */
+    store_reg(c, tmid, NOC_TARG_MID);
+    rv_buf_emit(c, rv_sw(rreg, RV_T0, NOC_RET_LO));    /* return low from reg */
+    store_reg(c, rmid, NOC_RET_MID);
+    store_reg(c, len,  NOC_AT_LEN_BE);
+    store_reg(c, ctrl, NOC_CTRL);
+    store_reg(c, 1u,   NOC_CMD_CTRL);                  /* fire */
+    return BC_OK;
+}
+
+/* Spin until every transfer issued so far has completed: for reads, until the
+ * responses-received counter catches the requests-sent counter; for writes,
+ * until acks catch the (marked) requests sent. The docs require reading
+ * NOC_CMD_CTRL back before the first counter read so the fire and the poll are
+ * not reordered, so we do that first. Clobbers t0/t1/t2. */
+int
+tt_noc_barrier(rv_buf_t *c, int is_write)
+{
+    uint32_t sent = is_write ? CNT_WR_SENT : CNT_RD_REQ;
+    uint32_t got  = is_write ? CNT_WR_ACK  : CNT_RD_RESP;
+    uint32_t loop;
+    int32_t  off;
+
+    li32(c, RV_T0, NIU_BASE);
+    rv_buf_emit(c, rv_lw(RV_T1, RV_T0, NOC_CMD_CTRL));   /* ordering read-back */
+    li32(c, RV_T0, NIU_CNT_BASE);
+    loop = rv_buf_n_words(c);
+    rv_buf_emit(c, rv_lw(RV_T1, RV_T0, (int16_t)sent));
+    rv_buf_emit(c, rv_lw(RV_T2, RV_T0, (int16_t)got));
+    off = rv_buf_offset(c, rv_buf_n_words(c), loop);
+    rv_buf_emit(c, rv_bne(RV_T1, RV_T2, (int16_t)off));  /* sent != got ? loop */
+    return BC_OK;
 }

--- a/src/tensix/noc.c
+++ b/src/tensix/noc.c
@@ -1,0 +1,86 @@
+/*
+ * noc.c -- NoC transfer codegen for the baby RISC-V data-movement cores
+ *
+ * Lowers a tile read/write into the RISC-V store sequence that programs an NIU
+ * request initiator and triggers it. Register addresses from the Wormhole B0
+ * ISA docs (NoC/MemoryMap.md). The encoding is checkable with a RISC-V
+ * disassembler; whether the transfer actually moves the tile is a question
+ * only real hardware can answer.
+ */
+
+#include "barracuda.h"
+#include "rv_enc.h"
+#include "rv_buf.h"
+#include "noc.h"
+
+/* NIU request initiator 0 (NoC #0). */
+#define NIU_BASE        0xFFB20000u
+#define NOC_TARG_LO     0x00
+#define NOC_TARG_MID    0x04
+#define NOC_RET_LO      0x0C
+#define NOC_RET_MID     0x10
+#define NOC_CTRL        0x1C
+#define NOC_AT_LEN_BE   0x20
+#define NOC_CMD_CTRL    0x28
+
+/* NOC_CTRL request type (bits [1:0]). */
+#define NOC_CMD_RD      0u
+#define NOC_CMD_WR      2u
+
+/* RISC-V registers (ABI names): x5 = t0 base, x6 = t1 value, x0 = zero. */
+#define RV_X0   0
+#define RV_T0   5
+#define RV_T1   6
+
+/* Materialise a 32-bit value into reg via lui + addi, compensating for addi's
+ * sign extension of the low 12 bits. */
+static void
+li32(rv_buf_t *c, uint8_t reg, uint32_t v)
+{
+    uint32_t hi = (v >> 12) & 0xFFFFFu;
+    int32_t  lo = (int32_t)(v & 0xFFFu);
+    if (lo & 0x800) { lo -= 0x1000; hi = (hi + 1u) & 0xFFFFFu; }
+    if (hi) {
+        rv_buf_emit(c, rv_lui(reg, hi));
+        if (lo) rv_buf_emit(c, rv_addi(reg, reg, (int16_t)lo));
+    } else {
+        rv_buf_emit(c, rv_addi(reg, RV_X0, (int16_t)lo));
+    }
+}
+
+/* Store value v to NIU register at offset off from the base in t0. */
+static void
+store_reg(rv_buf_t *c, uint32_t v, int16_t off)
+{
+    li32(c, RV_T1, v);
+    rv_buf_emit(c, rv_sw(RV_T1, RV_T0, off));
+}
+
+static int
+noc_xfer(rv_buf_t *c, uint32_t ctrl, uint32_t tlo, uint32_t tmid,
+         uint32_t rlo, uint32_t rmid, uint32_t len)
+{
+    li32(c, RV_T0, NIU_BASE);
+    store_reg(c, tlo,  NOC_TARG_LO);
+    store_reg(c, tmid, NOC_TARG_MID);
+    store_reg(c, rlo,  NOC_RET_LO);
+    store_reg(c, rmid, NOC_RET_MID);
+    store_reg(c, len,  NOC_AT_LEN_BE);
+    store_reg(c, ctrl, NOC_CTRL);
+    store_reg(c, 1u,   NOC_CMD_CTRL);   /* write 1 to trigger the request */
+    return BC_OK;
+}
+
+int
+tt_noc_read(rv_buf_t *c, uint32_t tlo, uint32_t tmid,
+            uint32_t rlo, uint32_t rmid, uint32_t len)
+{
+    return noc_xfer(c, NOC_CMD_RD, tlo, tmid, rlo, rmid, len);
+}
+
+int
+tt_noc_write(rv_buf_t *c, uint32_t tlo, uint32_t tmid,
+             uint32_t rlo, uint32_t rmid, uint32_t len)
+{
+    return noc_xfer(c, NOC_CMD_WR, tlo, tmid, rlo, rmid, len);
+}

--- a/src/tensix/noc.h
+++ b/src/tensix/noc.h
@@ -27,6 +27,8 @@ int tt_noc_write(rv_buf_t *code, uint32_t targ_lo, uint32_t targ_mid,
 int tt_sem_inc    (rv_buf_t *code, uint32_t sem_lo, uint32_t sem_mid,
                    uint32_t incr);
 int tt_sem_wait_ge(rv_buf_t *code, uint32_t sem_addr, uint32_t threshold);
+int tt_sem_init   (rv_buf_t *code, uint32_t sem_addr, uint32_t val);
+int tt_sem_acquire(rv_buf_t *code, uint32_t sem_addr, uint32_t n);
 
 int tt_cb_reserve_back(rv_buf_t *code, uint32_t free_addr, uint32_t credits);
 int tt_cb_push_back   (rv_buf_t *code, uint32_t recv_lo, uint32_t recv_mid,

--- a/src/tensix/noc.h
+++ b/src/tensix/noc.h
@@ -3,27 +3,25 @@
 
 #include "rv_buf.h"
 
-/* NoC transfer primitive for the baby RISC-V data-movement cores.
- *
- * A transfer is programmed by storing to the NIU request-initiator registers
- * (NIU_BASE 0xFFB20000, initiator 0) and writing 1 to NOC_CMD_CTRL to trigger.
- * Each call appends the RISC-V `sw` sequence to `code`. Addresses are 36-bit:
- * _lo is the low 32 bits, _mid packs the high 4 bits with the remote tile's
- * NoC X/Y coordinates (see NoC/Coordinates.md). Register layout from the
- * Wormhole B0 ISA docs, NoC/MemoryMap.md.
- *
- * read:  remote(target) -> local L1(return).
- * write: local L1(target) -> remote(return).  (per NOC_CMD_WR semantics.) */
+/* NoC transfer primitive for the baby RISC-V data-movement cores. A transfer is
+ * programmed by storing to the NIU request-initiator registers (NIU_BASE
+ * 0xFFB20000, initiator 0) and writing 1 to NOC_CMD_CTRL to trigger, and each
+ * call appends the RISC-V `sw` sequence to `code`. Addresses are 36-bit: _lo is
+ * the low 32 bits, _mid packs the high 4 bits with the remote tile's NoC X/Y
+ * coordinates (see NoC/Coordinates.md), and the register layout comes from the
+ * Wormhole B0 ISA docs, NoC/MemoryMap.md. A read moves remote(target) to local
+ * L1(return); a write moves local L1(target) to remote(return), per NOC_CMD_WR
+ * semantics. */
 int tt_noc_read (rv_buf_t *code, uint32_t targ_lo, uint32_t targ_mid,
                  uint32_t ret_lo, uint32_t ret_mid, uint32_t len);
 int tt_noc_write(rv_buf_t *code, uint32_t targ_lo, uint32_t targ_mid,
                  uint32_t ret_lo, uint32_t ret_mid, uint32_t len);
 
 /* CB synchronisation. The signal (tt_sem_inc) is a NoC atomic increment of a
- * counter in a remote core's L1; the wait (tt_sem_wait_ge) is a local spin.
- * The four cb_* ops are these two under their producer/consumer names:
- *   producer: reserve_back (wait free) ... push_back (signal recv)
- *   consumer: wait_front  (wait recv) ... pop_front  (signal free) */
+ * counter in a remote core's L1; the wait (tt_sem_wait_ge) is a local spin. The
+ * four cb_* ops are these two under producer/consumer names: the producer does
+ * reserve_back (wait free) then push_back (signal recv), and the consumer does
+ * wait_front (wait recv) then pop_front (signal free). */
 int tt_sem_inc    (rv_buf_t *code, uint32_t sem_lo, uint32_t sem_mid,
                    uint32_t incr);
 int tt_sem_wait_ge(rv_buf_t *code, uint32_t sem_addr, uint32_t threshold);

--- a/src/tensix/noc.h
+++ b/src/tensix/noc.h
@@ -1,0 +1,22 @@
+#ifndef BARRACUDA_TENSIX_NOC_H
+#define BARRACUDA_TENSIX_NOC_H
+
+#include "rv_buf.h"
+
+/* NoC transfer primitive for the baby RISC-V data-movement cores.
+ *
+ * A transfer is programmed by storing to the NIU request-initiator registers
+ * (NIU_BASE 0xFFB20000, initiator 0) and writing 1 to NOC_CMD_CTRL to trigger.
+ * Each call appends the RISC-V `sw` sequence to `code`. Addresses are 36-bit:
+ * _lo is the low 32 bits, _mid packs the high 4 bits with the remote tile's
+ * NoC X/Y coordinates (see NoC/Coordinates.md). Register layout from the
+ * Wormhole B0 ISA docs, NoC/MemoryMap.md.
+ *
+ * read:  remote(target) -> local L1(return).
+ * write: local L1(target) -> remote(return).  (per NOC_CMD_WR semantics.) */
+int tt_noc_read (rv_buf_t *code, uint32_t targ_lo, uint32_t targ_mid,
+                 uint32_t ret_lo, uint32_t ret_mid, uint32_t len);
+int tt_noc_write(rv_buf_t *code, uint32_t targ_lo, uint32_t targ_mid,
+                 uint32_t ret_lo, uint32_t ret_mid, uint32_t len);
+
+#endif /* BARRACUDA_TENSIX_NOC_H */

--- a/src/tensix/noc.h
+++ b/src/tensix/noc.h
@@ -19,4 +19,20 @@ int tt_noc_read (rv_buf_t *code, uint32_t targ_lo, uint32_t targ_mid,
 int tt_noc_write(rv_buf_t *code, uint32_t targ_lo, uint32_t targ_mid,
                  uint32_t ret_lo, uint32_t ret_mid, uint32_t len);
 
+/* CB synchronisation. The signal (tt_sem_inc) is a NoC atomic increment of a
+ * counter in a remote core's L1; the wait (tt_sem_wait_ge) is a local spin.
+ * The four cb_* ops are these two under their producer/consumer names:
+ *   producer: reserve_back (wait free) ... push_back (signal recv)
+ *   consumer: wait_front  (wait recv) ... pop_front  (signal free) */
+int tt_sem_inc    (rv_buf_t *code, uint32_t sem_lo, uint32_t sem_mid,
+                   uint32_t incr);
+int tt_sem_wait_ge(rv_buf_t *code, uint32_t sem_addr, uint32_t threshold);
+
+int tt_cb_reserve_back(rv_buf_t *code, uint32_t free_addr, uint32_t credits);
+int tt_cb_push_back   (rv_buf_t *code, uint32_t recv_lo, uint32_t recv_mid,
+                       uint32_t n);
+int tt_cb_wait_front  (rv_buf_t *code, uint32_t recv_addr, uint32_t n);
+int tt_cb_pop_front   (rv_buf_t *code, uint32_t free_lo, uint32_t free_mid,
+                       uint32_t n);
+
 #endif /* BARRACUDA_TENSIX_NOC_H */

--- a/src/tensix/noc.h
+++ b/src/tensix/noc.h
@@ -35,4 +35,14 @@ int tt_cb_wait_front  (rv_buf_t *code, uint32_t recv_addr, uint32_t n);
 int tt_cb_pop_front   (rv_buf_t *code, uint32_t free_lo, uint32_t free_mid,
                        uint32_t n);
 
+/* Materialise a 32-bit value into a register (lui+addi). */
+void tt_li32(rv_buf_t *code, uint8_t reg, uint32_t v);
+
+/* Register-sourced transfer (low addresses come from treg/rreg so a loop can
+ * advance them) and a completion barrier that spins until issued transfers
+ * have landed. is_write picks the write path (marked, ack-tracked). */
+int tt_noc_xfer_reg(rv_buf_t *code, int is_write, uint8_t treg, uint8_t rreg,
+                    uint32_t targ_mid, uint32_t ret_mid, uint32_t len);
+int tt_noc_barrier (rv_buf_t *code, int is_write);
+
 #endif /* BARRACUDA_TENSIX_NOC_H */

--- a/src/tensix/rt_args.h
+++ b/src/tensix/rt_args.h
@@ -2,40 +2,28 @@
 #define BARRACUDA_RT_ARGS_H
 
 /*
- * Tensix kernel runtime arguments layout.
+ * Tensix kernel runtime arguments layout. This is the shared contract between
+ * the BarraCUDA RV32IM isel (rv_isel.c), which emits LW from these offsets when
+ * lowering BIR_PARAM and the four CUDA coordinate intrinsics (threadIdx,
+ * blockIdx, blockDim, gridDim), and the host launcher
+ * (examples/koyeb_tensix_launch.cpp and any future deploy harness), which writes
+ * the matching struct into L1 at TD_L1_RTARG_BASE before dispatch. Both sides
+ * must agree on the offsets exactly, so the layout is versioned by living here
+ * and being consumed by name everywhere else; change it in one place or the
+ * kernel reads garbage.
  *
- * Shared contract between two pieces:
+ * The dispatch model is single-thread-per-core: each baby core runs one program
+ * and reads threadIdx = (0, 0, 0) on entry, so CUDA kernels that depend on
+ * threadIdx for parallelism still compile and run correctly, they just execute
+ * the "thread 0 alone" trajectory. Many-threads-per-core is future work with two
+ * options, either the launcher dispatches the same ELF N times with different
+ * thread_id_x values (correct but slow), or we lower threadIdx-dependent paths
+ * to SFPU SIMD (fast but a whole new emitter); both live well outside this layer
+ * and the runtime arg block accommodates either.
  *
- *   1. The BarraCUDA RV32IM isel (rv_isel.c), which emits LW from
- *      these offsets when lowering BIR_PARAM and the four CUDA
- *      coordinate intrinsics (threadIdx, blockIdx, blockDim,
- *      gridDim) into baby-core code.
- *
- *   2. The host launcher (examples/koyeb_tensix_launch.cpp and any
- *      future deploy harness), which writes the matching struct
- *      into L1 at TD_L1_RTARG_BASE before dispatching the kernel.
- *
- * Both sides must agree on these offsets exactly. Change them in
- * one place and the kernel reads garbage; the layout is therefore
- * versioned by being centralised here and consumed by name from
- * everywhere else.
- *
- * Single-thread-per-core dispatch model: each baby core runs one
- * program and reads threadIdx = (0, 0, 0) on entry. CUDA kernels
- * that depend on threadIdx for parallelism still compile and run
- * correctly, they just execute the "thread 0 alone" trajectory.
- * Many-threads-per-core dispatch is a future task that has two
- * options: (a) the launcher dispatches the same ELF N times with
- * different thread_id_x values, which is correct but slow; (b)
- * we lower threadIdx-dependent code paths to SFPU SIMD, which is
- * fast but is a whole new emitter. Both live well outside this
- * layer; the runtime arg block accommodates either.
- *
- * Bytes 0..47   coordinate intrinsics (4 x 3 ints)
- * Bytes 48..111 kernel parameters (16 x uint32_t slots)
- * Bytes 112..   reserved for future expansion
- *
- * Total used: 112 bytes. Reserved slab: TD_L1_RTARG_SIZE = 256.
+ * Bytes 0..47 hold the coordinate intrinsics (4 x 3 ints), bytes 48..111 the
+ * kernel parameters (16 x uint32_t slots), and bytes 112 onward are reserved.
+ * Total used is 112 bytes inside the 256-byte reserved slab TD_L1_RTARG_SIZE.
  */
 
 /* Coordinate-intrinsic offsets. The subop on a BIR_THREAD_ID etc.
@@ -54,16 +42,13 @@
 #define RT_ARG_OFF_GDIM_Y      40u
 #define RT_ARG_OFF_GDIM_Z      44u
 
-/* Kernel parameter slot block. Each kernel param (BIR_PARAM i)
- * occupies one 4-byte slot. The cap was 16 initially (the TPF/CBRW
- * number used elsewhere in TDF), but real CUDA kernels routinely
- * have 17-26 parameters once you count pointers, sizes, and
- * scalar inputs separately. Bumped to 32 to cover the actual
- * working set. Still fits inside the 256-byte L1 slab:
- *   48 (intrinsics) + 32 * 4 (kernel args) = 176 bytes used.
- *
- * Anyone hitting 32 should think hard about whether they want a
- * pointer to a struct in DRAM instead. */
+/* Kernel parameter slot block. Each kernel param (BIR_PARAM i) occupies one
+ * 4-byte slot. The cap was 16 initially (the TPF/CBRW number used elsewhere in
+ * TDF), but real CUDA kernels routinely have 17-26 parameters once you count
+ * pointers, sizes, and scalar inputs separately, so it was bumped to 32 to cover
+ * the actual working set. That still fits inside the 256-byte L1 slab: 48
+ * (intrinsics) + 32 * 4 (kernel args) = 176 bytes used. Anyone hitting 32 should
+ * think hard about whether they want a pointer to a struct in DRAM instead. */
 #define RT_ARG_KERNEL_BASE     48u
 #define RT_ARG_N_KERNEL_SLOTS  32u
 #define RT_ARG_OFF_KARG(i)     (RT_ARG_KERNEL_BASE + (i) * 4u)

--- a/src/tensix/rv_buf.c
+++ b/src/tensix/rv_buf.c
@@ -35,11 +35,10 @@ const uint32_t *rv_buf_data(const rv_buf_t *b)  { return b->words; }
 
 int32_t rv_buf_offset(const rv_buf_t *b, uint32_t from, uint32_t to)
 {
-    /* Word indices come in unsigned; convert to signed byte offset.
-     * The unused-parameter warning suppressor is here because the
-     * function doesn't strictly need the buffer pointer (offset is
-     * purely arithmetic on the indices), but taking it keeps the
-     * API uniform and gives us room to add bounds checks later. */
+    /* Word indices come in unsigned; convert to a signed byte offset. The
+     * buffer pointer isn't strictly needed since this is pure index arithmetic,
+     * hence the (void)b, but taking it keeps the API uniform and leaves room to
+     * add bounds checks later. */
     (void)b;
     return ((int32_t)to - (int32_t)from) * 4;
 }

--- a/src/tensix/rv_buf.h
+++ b/src/tensix/rv_buf.h
@@ -4,18 +4,13 @@
 #include "barracuda.h"
 
 /*
- * RV32IM code buffer.
- *
- * Append-only ring of 32-bit instruction words plus a small set of
- * helpers for back-patching forward references. Used by the isel to
- * accumulate a function body before handing it off to the ELF emitter.
- *
- * Fixed-size arena, no malloc; if a kernel ever needs more than
- * RV_BUF_MAX_WORDS the emit calls return -1 and the caller bails.
- * 16 KiB of code is enough for any single baby-core kernel we have
- * a realistic plan to compile in the foreseeable future, and the
- * Tensix L1 only reserves about 32 KiB for code anyway, so spending
- * more memory here would just hide the overflow rather than fix it.
+ * RV32IM code buffer: an append-only ring of 32-bit instruction words plus a
+ * few helpers for back-patching forward references, used by the isel to build
+ * a function body before handing it to the ELF emitter. It's a fixed-size
+ * arena with no malloc, so past RV_BUF_MAX_WORDS the emit calls return -1 and
+ * the caller bails. 16 KiB is plenty for any baby-core kernel we plan to
+ * compile, and the Tensix L1 only reserves about 32 KiB for code, so a bigger
+ * buffer would just hide the overflow rather than fix it.
  */
 
 #define RV_BUF_MAX_WORDS  4096    /* 16 KiB of instruction storage */
@@ -27,14 +22,14 @@ typedef struct {
 
 void           rv_buf_init(rv_buf_t *b);
 
-/* Append one word, return its index (0..n-1) or -1 on overflow.
- * Most callers don't need the index but the isel reaches for it
- * when it wants to back-patch a forward branch later. */
+/* Append one word, return its index (0..n-1) or -1 on overflow. Most callers
+ * ignore the index, but the isel reaches for it to back-patch a forward
+ * branch later. */
 int            rv_buf_emit(rv_buf_t *b, uint32_t word);
 
-/* Overwrite a previously emitted word. Used by the isel once a
- * forward-reference label is resolved and the original placeholder
- * branch can be filled in with the right offset. */
+/* Overwrite a previously emitted word, used by the isel once a forward-reference
+ * label resolves and the placeholder branch can be filled in with the right
+ * offset. */
 int            rv_buf_patch(rv_buf_t *b, uint32_t idx, uint32_t word);
 
 uint32_t       rv_buf_n_words(const rv_buf_t *b);
@@ -42,15 +37,10 @@ uint32_t       rv_buf_pos_bytes(const rv_buf_t *b);   /* n * 4 */
 const uint32_t *rv_buf_data(const rv_buf_t *b);
 
 /*
- * Compute the byte offset from word index `from` to word index `to`.
- * Negative for backward references, positive for forward. Used by
- * the isel when filling in B-type and J-type immediate fields:
- *
- *   uint32_t br_idx = rv_buf_emit(b, 0);             // placeholder
- *   ... emit more code ...
- *   uint32_t tgt_idx = rv_buf_n_words(b);            // branch target
- *   int32_t  off = rv_buf_offset(b, br_idx, tgt_idx);
- *   rv_buf_patch(b, br_idx, rv_beq(rs1, rs2, off));
+ * Compute the byte offset from word index `from` to word index `to`, negative
+ * for backward references and positive for forward. The isel uses it to fill in
+ * B-type and J-type immediate fields: emit a placeholder word, keep emitting,
+ * then patch the placeholder with the offset from its index to the branch target.
  */
 int32_t        rv_buf_offset(const rv_buf_t *b,
                              uint32_t from, uint32_t to);

--- a/src/tensix/rv_elf.c
+++ b/src/tensix/rv_elf.c
@@ -3,15 +3,12 @@
 #include <string.h>
 
 /*
- * ELF32 little-endian header writer. Constants are inlined as
- * literals rather than included from elf.h because there is no
- * portable elf.h on Windows/MinGW and inlining keeps the build
- * dependency-free, which is the whole point of this compiler.
- *
- * All multibyte fields are written little-endian, which matches
- * both the ELFDATA2LSB declaration and the host x86-64 byte order
- * the compiler runs on. The native-write below assumes that;
- * porting to a big-endian compiler host would need explicit
+ * ELF32 little-endian header writer. The constants are inlined as literals
+ * rather than pulled from elf.h because there's no portable elf.h on
+ * Windows/MinGW, and inlining keeps the build dependency-free, which is the
+ * whole point of this compiler. All multibyte fields are written little-endian,
+ * matching both the ELFDATA2LSB declaration and the host x86-64 byte order the
+ * compiler runs on. Porting to a big-endian host would need explicit
  * byte-swizzling, which is a problem we can have when we have it.
  */
 
@@ -66,11 +63,9 @@ static void w32(uint8_t  **p, uint32_t v)
 
 /* ---- Header builders ---- */
 
-/* Section names live in a tiny string table. Indices into the table:
- *   0: empty string (every strtab starts with NUL)
- *   1: ".text"      (length 5 + NUL = 6)
- *   7: ".shstrtab"  (length 9 + NUL = 10)
- * Total: 17 bytes. */
+/* Section names live in a tiny 17-byte string table: offset 0 is the empty
+ * string every strtab starts with, offset 1 is ".text" (5 chars plus NUL) and
+ * offset 7 is ".shstrtab" (9 chars plus NUL). */
 static const char k_shstrtab[] = "\0.text\0.shstrtab\0";
 #define SHSTRTAB_SIZE   17u
 #define SHSTR_OFF_TEXT  1u
@@ -175,10 +170,9 @@ int rv_elf_write(const rv_buf_t *code, const char *path)
     rv_elf_lay_t lay;
     plan_layout(code_bytes, &lay);
 
-    /* Fixed maximum size: 16 KiB code + 256 bytes of header/section
-     * metadata is well under what we want to hold in a stack frame
-     * but the file write below uses the buffer as a single blob,
-     * so we cap it here and refuse anything bigger. */
+    /* Fixed maximum size of 16 KiB code plus 256 bytes of header and section
+     * metadata. The write below treats the buffer as a single blob, so we cap it
+     * here and refuse anything bigger. */
     static uint8_t out[RV_BUF_MAX_WORDS * 4u + 256u];
     if (lay.total_sz > sizeof(out)) {
         fprintf(stderr,

--- a/src/tensix/rv_elf.h
+++ b/src/tensix/rv_elf.h
@@ -5,50 +5,36 @@
 #include "rv_buf.h"
 
 /*
- * RV32IM ELF emitter for the Tenstorrent Wormhole baby RISC-V cores.
+ * RV32IM ELF emitter for the Tenstorrent Wormhole baby RISC-V cores. The file
+ * it produces is an ELF32 header, a PT_LOAD program header, 4-byte-aligned code,
+ * the .shstrtab contents, and a three-entry section header table. The constants
+ * below come from the System V ABI ELF32 spec and sfpi-binutils common.h
+ * (ELFCLASS32=1, ELFDATA2LSB=1, ET_EXEC=2, EM_RISCV=243, EV_CURRENT=1); the L1
+ * base of 0x00000000 comes from the tt-isa-documentation BabyRISCV README, and
+ * the tt-metal SDK loads via PT_LOAD with sections as optional metadata any
+ * reasonable disassembler will read.
  *
- * Layout of the produced file:
- *   [ELF32 header, 52 bytes]
- *   [PT_LOAD program header, 32 bytes]
- *   [code bytes, 4-byte aligned]
- *   [.shstrtab contents]
- *   [Section header table, 3 entries * 40 bytes]
- *
- * Spec sources:
- *   System V ABI ELF32 specification (the constants below are from
- *   the standard elf.h on any Linux box).
- *   sfpi-binutils/include/elf/common.h, ELFCLASS32 = 1, ELFDATA2LSB = 1,
- *   ET_EXEC = 2, EM_RISCV = 243, EV_CURRENT = 1.
- *   tt-isa-documentation/WormholeB0/TensixTile/BabyRISCV/README.md
- *   for the L1 base address being 0x00000000 and code living there.
- *   tt-metal SDK loads via PT_LOAD; sections are optional metadata
- *   that any reasonable disassembler will read.
- *
- * Soft-float ABI, no compressed instructions, no F/D extension:
- *   e_flags = 0. EF_RISCV_FLOAT_ABI_SOFT happens to also be 0 so this
- *   is correct rather than accidentally correct.
- *
- * What this emitter does NOT do today: relocations, symbol tables,
- * debug info, BSS. The current path expects the kernel to be
- * self-contained code with no external symbol references, which is
- * fine for the first integer-only bring-up.
+ * It's a soft-float ABI with no compressed instructions and no F/D extension, so
+ * e_flags = 0; EF_RISCV_FLOAT_ABI_SOFT happens to also be 0, so this is correct
+ * rather than accidentally correct. What it does NOT do today is relocations,
+ * symbol tables, debug info, or BSS: the current path expects a self-contained
+ * kernel with no external symbol references, which is fine for the first
+ * integer-only bring-up.
  */
 
 /* L1 base address where code is loaded. Spec source above. */
 #define RV_ELF_LOAD_ADDR  0x00000000u
 
-/* Entry point at the start of code; spec is silent on whether the
- * tt-metal loader honours e_entry or assumes a known address, so
- * we set both to RV_ELF_LOAD_ADDR and hope they line up. The PC
- * register that gets written by the host on launch lives in
- * Tensix MMIO and is undocumented in the public ISA reference. */
+/* Entry point at the start of code. The spec is silent on whether the tt-metal
+ * loader honours e_entry or assumes a known address, so we set both to
+ * RV_ELF_LOAD_ADDR and hope they line up. The PC register the host writes on
+ * launch lives in Tensix MMIO and is undocumented in the public ISA reference. */
 #define RV_ELF_ENTRY      RV_ELF_LOAD_ADDR
 
 /*
- * Write the contents of a code buffer to an RV32IM ELF file at the
- * given path. Returns BC_OK on success or a BC_ERR_* code on
- * failure. The caller is responsible for any post-write actions
- * such as chmod or staging onto the deploy host.
+ * Write a code buffer to an RV32IM ELF file at the given path. Returns BC_OK on
+ * success or a BC_ERR_* code on failure. The caller handles any post-write steps
+ * like chmod or staging onto the deploy host.
  */
 int rv_elf_write(const rv_buf_t *code, const char *path);
 

--- a/src/tensix/rv_enc.c
+++ b/src/tensix/rv_enc.c
@@ -65,13 +65,10 @@ static uint32_t enc_s(int16_t imm, uint8_t rs2, uint8_t rs1,
 static uint32_t enc_b(int16_t offset, uint8_t rs1, uint8_t rs2,
                       uint32_t f3, uint32_t op)
 {
-    /* B-type immediate scrambling, spec p.24 and p.30:
-     *   inst[31]    = imm[12]
-     *   inst[30:25] = imm[10:5]
-     *   inst[11:8]  = imm[4:1]
-     *   inst[7]     = imm[11]
-     * Bit 0 of the offset is always zero because branch targets
-     * are 2-byte aligned and the encoding has no room for it. */
+    /* B-type immediate scrambling, spec p.24 and p.30: bit 12 goes to
+     * inst[31], bits 10:5 to inst[30:25], bits 4:1 to inst[11:8], and bit
+     * 11 to inst[7]. Bit 0 of the offset is always zero because branch
+     * targets are 2-byte aligned and the encoding has no room for it. */
     uint32_t u  = (uint32_t)offset & 0x1FFFu;     /* 13-bit field */
     uint32_t b12 = (u >> 12) & 0x1u;
     uint32_t b11 = (u >> 11) & 0x1u;
@@ -99,13 +96,11 @@ static uint32_t enc_u(uint32_t imm_hi20, uint8_t rd, uint32_t op)
 
 static uint32_t enc_j(int32_t offset, uint8_t rd, uint32_t op)
 {
-    /* J-type immediate scrambling, spec p.24:
-     *   inst[31]    = imm[20]
-     *   inst[30:21] = imm[10:1]
-     *   inst[20]    = imm[11]
-     *   inst[19:12] = imm[19:12]
-     * Same trick as B-type: middle bits stay put, sign bit at top,
-     * the 11/12-bit boundary slots in where there is room. */
+    /* J-type immediate scrambling, spec p.24: bit 20 goes to inst[31],
+     * bits 10:1 to inst[30:21], bit 11 to inst[20], and bits 19:12 stay
+     * at inst[19:12]. Same trick as B-type, the middle bits stay put, the
+     * sign bit sits at top, and the 11/12-bit boundary slots in where
+     * there is room. */
     uint32_t u  = (uint32_t)offset & 0x1FFFFFu;       /* 21-bit field */
     uint32_t b20    = (u >> 20) & 0x1u;
     uint32_t b19_12 = (u >> 12) & 0xFFu;
@@ -190,14 +185,12 @@ uint32_t rv_remu  (uint8_t rd, uint8_t rs1, uint8_t rs2) { return enc_r(0x01, rs
 
 uint32_t rv_fence(uint8_t pred, uint8_t succ)
 {
-    /* FENCE encoding, spec p.32:
-     *   bits[31:28] = fm (zero for normal fence)
-     *   bits[27:24] = pred (memory operations before)
-     *   bits[23:20] = succ (memory operations after)
-     *   rs1 = 0, funct3 = 0, rd = 0, opcode = 0x0F
-     * Baby cores treat the whole thing as a nop but we emit the
-     * canonical encoding so future hardware revisions and any
-     * downstream disassembler see the right bits. */
+    /* FENCE encoding, spec p.32: fm in bits[31:28] is zero for a normal
+     * fence, pred (operations before) in bits[27:24], succ (operations
+     * after) in bits[23:20], with rs1, funct3 and rd all zero on opcode
+     * 0x0F. Baby cores treat the whole thing as a nop but we emit the
+     * canonical encoding so future hardware revisions and any downstream
+     * disassembler see the right bits. */
     return ((uint32_t)(pred & 0xFu) << 24)
          | ((uint32_t)(succ & 0xFu) << 20)
          | 0x0Fu;

--- a/src/tensix/rv_enc.h
+++ b/src/tensix/rv_enc.h
@@ -4,30 +4,19 @@
 #include "barracuda.h"
 
 /*
- * RV32IM instruction encoder for the Tenstorrent Wormhole baby
- * RISC-V cores. Pure bit-packing, no assembler, no parser. Each
- * function returns a 32-bit little-endian instruction word.
+ * RV32IM instruction encoder for the Tenstorrent Wormhole baby RISC-V
+ * cores. Pure bit-packing, no assembler or parser, each function returns
+ * a 32-bit little-endian instruction word. Spec sources are cited inline
+ * next to each opcode (the Unprivileged ISA PDF and the BabyRISCV README).
  *
- * Spec sources cited inline next to each opcode:
- *   docs/RISC-V_Unprivileged_ISA_2024.pdf
- *   tt-isa-documentation/WormholeB0/TensixTile/BabyRISCV/README.md
- *
- * RV32I base + M extension only. No F/D/A/C/V/CSR. The baby cores
- * do not implement those and the .ttinsn coprocessor extension
- * lives in a separate emitter once we get there.
- *
- * Calling convention reminder (from spec page 21):
- *   x0       hard zero
- *   x1       ra, return address
- *   x2       sp, stack pointer
- *   x10-x17  a0-a7, argument and return registers
- *   x5-x7    t0-t2, temporaries (caller-saved)
- *   x28-x31  t3-t6, temporaries (caller-saved)
- *   x8-x9    s0-s1, callee-saved
- *   x18-x27  s2-s11, callee-saved
- *
- * Soft-float libcalls pass FP values in a0/a1 and return there too,
- * which is what the soft-float runtime expects when we link it in.
+ * RV32I base plus the M extension only, no F/D/A/C/V/CSR: the baby cores
+ * do not implement those, and the .ttinsn coprocessor extension lives in
+ * a separate emitter once we get there. The calling convention (spec page
+ * 21) is the standard one: x0 hard zero, x1 ra, x2 sp, x5-x7 and x28-x31
+ * the caller-saved temporaries, x10-x17 the argument/return registers, and
+ * x8-x9 with x18-x27 callee-saved. Soft-float libcalls pass FP values in
+ * a0/a1 and return there too, which is what the soft-float runtime expects
+ * when we link it in.
  */
 
 /* ---- Register names ---- */

--- a/src/tensix/rv_isel.c
+++ b/src/tensix/rv_isel.c
@@ -6,24 +6,15 @@
 #include <string.h>
 
 /*
- * Bring-up isel: stack-spill every BIR value, walk the instruction
- * stream once, emit a small pattern per opcode. The stack frame
- * layout is:
- *
- *   sp + 0     : saved ra (always saved, leaf or not, to keep the
- *                prologue uniform; the host loader does not care)
- *   sp + 4     : reserved padding to keep 16-byte alignment
- *   sp + 8     : slot for BIR value 0
- *   sp + 12    : slot for BIR value 1
- *   ...
- *
- * Each BIR instruction's stack slot is at sp + ISEL_LOCALS_BASE +
- * (bir_inst_index * 4). Constants do not get their own slot; they
- * are materialised into t0/t1 on demand.
- *
- * The frame size must be 16-byte aligned (RISC-V psABI for soft-float
- * RV32; cite Unprivileged ISA appendix on the integer calling
- * convention).
+ * Bring-up isel: stack-spill every BIR value, walk the instruction stream
+ * once, emit a small pattern per opcode. The frame keeps saved ra at sp+0
+ * (always saved, leaf or not, to keep the prologue uniform; the host
+ * loader does not care), reserved padding at sp+4 for 16-byte alignment,
+ * then one 4-byte slot per BIR value from sp+8 onward. Each instruction's
+ * slot lives at sp + ISEL_LOCALS_BASE + bir_inst_index * 4; constants get
+ * no slot and are materialised into t0/t1 on demand. The frame size must
+ * be 16-byte aligned per the RISC-V soft-float RV32 psABI (Unprivileged
+ * ISA appendix on the integer calling convention).
  */
 
 #define ISEL_LOCALS_BASE  8u           /* bytes; ra + pad */
@@ -374,15 +365,11 @@ static int sel_cast_id(const bir_module_t *M, uint32_t inst_idx,
  *
  * Source and destination integer widths come from the operand and
  * the result type respectively. The lowering is straight out of the
- * Unprivileged ISA spec page 26 (shift idioms):
- *
- *   ZEXT to wider:  AND with (1<<src_w)-1
- *                   (for src_w<=11 the mask fits in ANDI; for 16/24
- *                   we use SLLI/SRLI to clear high bits)
- *   SEXT to wider:  SLLI (32-src_w), then SRAI (32-src_w)
- *   TRUNC narrower: same mask trick to clear high bits
- *
- * The shift-twice idiom works for any source width up to 31 and
+ * Unprivileged ISA spec page 26 (shift idioms): a zero-extend masks with
+ * (1<<src_w)-1, done via SLLI/SRLI to clear the high bits rather than an
+ * ANDI whose immediate cannot reach 16 or 24 bits; a sign-extend is SLLI
+ * by (32-src_w) then SRAI back; and a truncate uses the same clear-the-
+ * high-bits trick. The shift-twice idiom works for any source width up to 31 and
  * gives the right answer regardless of whatever was in the high
  * bits before, which is the assumption we have to make because the
  * slot store/load pipeline keeps 32-bit values without tracking
@@ -945,15 +932,11 @@ static int gep_add_byte_offset(int64_t off, rv_buf_t *out)
 }
 
 /*
- * GEP lowering. Two shapes:
- *
- *   1. Struct-field GEP: base is a pointer-to-struct, the index
- *      operand is a constant field number. Offset is computed
- *      from the struct's layout.
- *
- *   2. Array-stride GEP: base is anything else (pointer to a
- *      primitive, decayed array, vector). Offset is index times
- *      the element size of the GEP's result pointee.
+ * GEP lowering comes in two shapes. A struct-field GEP has a pointer-to-
+ * struct base and a constant field number for the index, and its offset
+ * comes from the struct's layout. An array-stride GEP has any other base
+ * (pointer to a primitive, decayed array, vector) and its offset is the
+ * index times the element size of the GEP's result pointee.
  *
  * The distinction is made by inspecting the BASE operand's type,
  * not the result type, because the BIR encoding changes the

--- a/src/tensix/rv_isel.h
+++ b/src/tensix/rv_isel.h
@@ -9,27 +9,20 @@
 /*
  * BIR -> RV32IM instruction selection for the Tenstorrent baby cores.
  *
- * This is the bring-up version: stack-spill every BIR value into its
- * own 4-byte slot, no register allocation, no peephole optimisation,
- * no calling-convention sophistication beyond "the function is leaf
- * and integer-only." That means the generated code is correct and
- * uniform but slow; the point is to get a kernel running on the
- * n300 first and improve once we have something to measure.
+ * This is the bring-up version: stack-spill every BIR value into its own
+ * 4-byte slot, no register allocation, no peephole optimisation, and no
+ * calling-convention sophistication beyond "the function is leaf and
+ * integer-only." The generated code is correct and uniform but slow; the
+ * point is to get a kernel running on the n300 first and improve once we
+ * have something to measure.
  *
- * What it handles today:
- *   BIR_PARAM    parameter i goes from a0+i into its stack slot
- *   BIR_LOAD     i32 loads through a pointer parameter
- *   BIR_STORE    i32 stores through a pointer parameter
- *   BIR_ADD/SUB/MUL  integer arithmetic with t0/t1 scratch
- *   BIR_RET      return integer in a0, or void
- *   BIR_CONST    materialise small constants via ADDI
- *
- * What it does NOT handle (yet):
- *   BIR_CALL, control flow, GEP, floats, vectors, structs.
- *   Calling more than 8 integer parameters.
- *   Constants outside the I-type 12-bit signed range (needs LUI+ADDI).
- *
- * Spec sources cited in the .c file alongside each opcode emission.
+ * Today it handles parameters, i32 loads and stores through a pointer,
+ * integer arithmetic with t0/t1 scratch, integer or void returns, and
+ * small constants materialised via ADDI. It does not yet handle the
+ * harder cases (calls, control flow, GEP, floats, vectors, structs), more
+ * than 8 integer parameters, or constants outside the I-type 12-bit
+ * signed range that would need LUI+ADDI. Spec sources are cited in the .c
+ * file alongside each opcode emission.
  */
 
 /*

--- a/src/tensix/tensix.h
+++ b/src/tensix/tensix.h
@@ -283,6 +283,7 @@ typedef struct {
     uint32_t out_free_addr;     /* local: output free-counter (reserve_back)   */
     uint32_t out_recv_lo;       /* remote: output produced-counter (push_back) */
     uint32_t out_recv_mid;
+    uint32_t out_depth;         /* output CB ring depth (seeds out_free)       */
 } tt_compute_sync_t;
 
 /* Weave the compute body into a baby-core RISC-V program: a per-tile loop that

--- a/src/tensix/tensix.h
+++ b/src/tensix/tensix.h
@@ -35,6 +35,7 @@ typedef enum {
     TT_FMT_C,          /* [op:8][imm16:16][dst:4][mod1:4] */
     TT_FMT_D,          /* [op:8][lreg:4][mod0:4][addr_mode:2][dest_addr:14] */
     TT_FMT_E,          /* [op:8][lreg:4][mod0:4][imm16:16] */
+    TT_FMT_SYNC,       /* Sync Unit ops; per-opcode field layout (see emit.c) */
     TT_FMT_PSEUDO,
     TT_FMT_COUNT
 } tt_fmt_t;
@@ -96,6 +97,12 @@ typedef enum {
 
     TT_SFPNOP           = 0x02,
     TT_SFPWNOP          = 0x8F,
+
+    /* Sync Unit (semaphores / stalls), opcodes from ttas/sfpi-binutils */
+    TT_STALLWAIT        = 0xA2,
+    TT_SEMINIT          = 0xA3,
+    TT_SEMPOST          = 0xA4,
+    TT_SEMWAIT          = 0xA6,
 
     TT_PSEUDO_PHI,
     TT_PSEUDO_COPY,

--- a/src/tensix/tensix.h
+++ b/src/tensix/tensix.h
@@ -300,5 +300,9 @@ int  tensix_emit_writer(const tt_module_t *tt, const tt_dmov_t *dmov,
 int  tensix_emit_host_full(const tt_module_t *tt, const tt_dmov_t *dmov,
                            const char *host_path, const char *reader_path,
                            const char *compute_path, const char *writer_path);
+/* Emit the three baby-core ELFs (reader/compute/writer) with one shared L1
+ * address layout. Writes <stem>_reader.elf, <stem>_compute.elf, <stem>_writer.elf. */
+int  tensix_emit_kernel_elves(tt_module_t *tt, const tt_dmov_t *dmov,
+                              const char *stem);
 
 #endif /* BARRACUDA_TENSIX_H */

--- a/src/tensix/tensix.h
+++ b/src/tensix/tensix.h
@@ -2,6 +2,7 @@
 #define BARRACUDA_TENSIX_H
 
 #include "bir.h"
+#include "rv_buf.h"     /* rv_buf_t, for the compute-core weave */
 
 /* Tenstorrent Tensix backend. 32-lane SFPU, 8 writable LRegs, predicated
  * execution, no branches, and a register that contains 0.8373.
@@ -268,6 +269,26 @@ void tensix_regalloc(tt_module_t *tt);
 int  tensix_emit_metalium(tt_module_t *tt, const char *path);
 int  tensix_emit_binary(tt_module_t *tt, const char *path);   /* raw Tensix words */
 int  tensix_emit_ttinsn(tt_module_t *tt, const char *path);   /* RISC-V .ttinsn stream */
+
+/* CB addresses the compute core synchronises against. As consumer of its input
+ * CB it waits on `in_recv` (local) and releases via the producer's `in_free`
+ * (remote); as producer of its output CB it waits on `out_free` (local) and
+ * signals the consumer's `out_recv` (remote). Same-tile placement makes the
+ * remote mids zero. */
+typedef struct {
+    uint32_t ntiles_addr;       /* L1 address of the tile-count runtime arg */
+    uint32_t in_recv_addr;      /* local: input produced-counter (wait_front) */
+    uint32_t in_free_lo;        /* remote: input free-counter (pop_front)      */
+    uint32_t in_free_mid;
+    uint32_t out_free_addr;     /* local: output free-counter (reserve_back)   */
+    uint32_t out_recv_lo;       /* remote: output produced-counter (push_back) */
+    uint32_t out_recv_mid;
+} tt_compute_sync_t;
+
+/* Weave the compute body into a baby-core RISC-V program: a per-tile loop that
+ * brackets the .ttinsn issue stream with the CB handshake. */
+int  tensix_emit_compute_rv(tt_module_t *tt, rv_buf_t *code,
+                            const tt_compute_sync_t *s);
 /* Data movement — Tier 4 */
 void tensix_analyze_datamov(const bir_module_t *bir, const tt_module_t *tt,
                             tt_dmov_t *dmov);

--- a/src/tensix/tensix.h
+++ b/src/tensix/tensix.h
@@ -259,6 +259,7 @@ int  tensix_compile(const bir_module_t *bir, tt_module_t *tt);
 void tensix_coarsen(tt_module_t *tt);
 void tensix_regalloc(tt_module_t *tt);
 int  tensix_emit_metalium(tt_module_t *tt, const char *path);
+int  tensix_emit_binary(tt_module_t *tt, const char *path);   /* raw Tensix words */
 /* Data movement — Tier 4 */
 void tensix_analyze_datamov(const bir_module_t *bir, const tt_module_t *tt,
                             tt_dmov_t *dmov);

--- a/src/tensix/tensix.h
+++ b/src/tensix/tensix.h
@@ -260,6 +260,7 @@ void tensix_coarsen(tt_module_t *tt);
 void tensix_regalloc(tt_module_t *tt);
 int  tensix_emit_metalium(tt_module_t *tt, const char *path);
 int  tensix_emit_binary(tt_module_t *tt, const char *path);   /* raw Tensix words */
+int  tensix_emit_ttinsn(tt_module_t *tt, const char *path);   /* RISC-V .ttinsn stream */
 /* Data movement — Tier 4 */
 void tensix_analyze_datamov(const bir_module_t *bir, const tt_module_t *tt,
                             tt_dmov_t *dmov);

--- a/tests/tcbsync.c
+++ b/tests/tcbsync.c
@@ -7,6 +7,9 @@
 #include "rv_buf.h"
 #include "rv_enc.h"
 #include "noc.h"
+#include "tensix.h"
+#include <stdlib.h>
+#include <string.h>
 
 /* NIU register file base, high 20 bits (the lui immediate). 0xFFB20000. */
 #define NIU_LUI 0xFFB20u
@@ -100,3 +103,57 @@ static void cb_wait_front_is_wait_ge(void)
     PASS();
 }
 TH_REG("tensix", cb_wait_front_is_wait_ge);
+
+/* ---- compute weave brackets the issue stream with the CB handshake ---- */
+
+static void compute_weave_brackets_issue(void)
+{
+    tt_module_t *m = (tt_module_t *)malloc(sizeof *m);
+    tt_compute_sync_t s;
+    uint32_t n, last;
+
+    CHECK(m != NULL);
+    memset(m, 0, sizeof *m);
+    /* two real Tensix ops as the body. */
+    m->minsts[0].op = TT_SFPADD; m->minsts[0].fmt = TT_FMT_A;
+    m->minsts[1].op = TT_SFPMUL; m->minsts[1].fmt = TT_FMT_A;
+    m->num_minsts = 2u;
+
+    memset(&s, 0, sizeof s);
+    s.ntiles_addr   = 0x8030u;
+    s.in_recv_addr  = 0xA100u;
+    s.in_free_lo    = 0x9000u;
+    s.out_free_addr = 0xB100u;
+    s.out_recv_lo   = 0x9100u;
+
+    rv_buf_init(&B);
+    CHEQ(tensix_emit_compute_rv(m, &B, &s), BC_OK);
+
+    n = rv_buf_n_words(&B);
+    CHECK(n > 8u);
+    /* a CB wait is a spin: lw then bltu back by one word. */
+    CHECK(find_word(rv_bltu(RV_T1, RV_T2, -4)) >= 0);
+    /* a CB signal is an atomic increment: NOC_AT_LEN_BE = 0x107C materialised. */
+    CHECK(find_word(rv_addi(RV_T1, RV_T1, 0x7C)) >= 0);
+    /* the loop has an exit branch: beq <reg>, zero, done. */
+    {
+        int found_exit = 0;
+        uint32_t k;
+        for (k = 0; k < n; k++) {
+            uint32_t w = rv_buf_data(&B)[k];
+            if ((w & 0x7fu) == 0x63u             /* BRANCH        */
+             && ((w >> 12) & 7u) == 0u           /* funct3 = beq  */
+             && ((w >> 20) & 0x1fu) == 0u) {     /* rs2 = zero    */
+                found_exit = 1; break;
+            }
+        }
+        CHECK(found_exit);
+    }
+    /* and the loop closes with a back jump. */
+    last = rv_buf_data(&B)[n - 1u];
+    CHEQ(last & 0x7fu, 0x6fu);                         /* JAL  */
+    CHEQ((last >> 7) & 0x1fu, 0u);                     /* rd == zero */
+    free(m);
+    PASS();
+}
+TH_REG("tensix", compute_weave_brackets_issue);

--- a/tests/tcbsync.c
+++ b/tests/tcbsync.c
@@ -1,0 +1,102 @@
+/* tcbsync.c -- Tensix circular-buffer synchronisation primitive tests.
+ * The signal is a NoC atomic increment of a remote L1 counter; the wait is a
+ * local spin. Check the emitted RV32I against the rv_enc encoders so the test
+ * documents the exact instruction stream the hardware would fetch. */
+
+#include "tharns.h"
+#include "rv_buf.h"
+#include "rv_enc.h"
+#include "noc.h"
+
+/* NIU register file base, high 20 bits (the lui immediate). 0xFFB20000. */
+#define NIU_LUI 0xFFB20u
+
+static rv_buf_t B;
+
+/* Find the first word equal to `w`, or -1. */
+static int find_word(uint32_t w)
+{
+    const uint32_t *d = rv_buf_data(&B);
+    uint32_t n = rv_buf_n_words(&B);
+    for (uint32_t i = 0; i < n; i++) if (d[i] == w) return (int)i;
+    return -1;
+}
+
+/* ---- the signal programs the NIU for a full-width atomic increment ---- */
+
+static void cb_sem_inc_encodes_atomic(void)
+{
+    rv_buf_init(&B);
+    /* increment counter at remote 0x00009000, coords 0x00001234, by 1. */
+    CHEQ(tt_sem_inc(&B, 0x00009000u, 0x00001234u, 1u), BC_OK);
+
+    const uint32_t *d = rv_buf_data(&B);
+    uint32_t n = rv_buf_n_words(&B);
+
+    /* base register set up first. */
+    CHEQ(d[0], rv_lui(RV_T0, NIU_LUI));
+
+    /* NOC_AT_LEN_BE (offset 0x20) is loaded with 0x107C: op=1 in [15:12]
+     * (lui t1,1 ; addi t1,t1,0x7C) then stored. */
+    int s = find_word(rv_sw(RV_T1, RV_T0, 0x20));
+    CHECK(s >= 2);
+    CHEQ(d[s - 2], rv_lui (RV_T1, 1u));
+    CHEQ(d[s - 1], rv_addi(RV_T1, RV_T1, 0x7C));
+
+    /* request type NOC_CMD_AT (1) stored to NOC_CTRL (0x1C). */
+    CHECK(find_word(rv_sw(RV_T1, RV_T0, 0x1C)) >= 0);
+
+    /* last thing done is fire: write 1 to NOC_CMD_CTRL (0x28). */
+    CHEQ(d[n - 2], rv_addi(RV_T1, RV_X0, 1));
+    CHEQ(d[n - 1], rv_sw  (RV_T1, RV_T0, 0x28));
+    PASS();
+}
+TH_REG("tensix", cb_sem_inc_encodes_atomic);
+
+/* ---- the wait is a two-instruction spin that branches back on itself ---- */
+
+static void cb_wait_is_spin_loop(void)
+{
+    rv_buf_init(&B);
+    CHEQ(tt_sem_wait_ge(&B, 0x00009000u, 4u), BC_OK);
+
+    const uint32_t *d = rv_buf_data(&B);
+    uint32_t n = rv_buf_n_words(&B);
+
+    /* loop body: reload the counter, branch back to the load if it is
+     * still below the threshold. The branch displacement is -4 (one word). */
+    CHEQ(d[n - 2], rv_lw  (RV_T1, RV_T0, 0));
+    CHEQ(d[n - 1], rv_bltu(RV_T1, RV_T2, -4));
+    PASS();
+}
+TH_REG("tensix", cb_wait_is_spin_loop);
+
+/* ---- the CB ops are the wait/signal pair under pipeline names ---- */
+
+static void cb_push_is_sem_inc(void)
+{
+    static rv_buf_t A;
+    rv_buf_init(&A);
+    rv_buf_init(&B);
+    tt_cb_push_back(&A, 0x9000u, 0x1234u, 2u);
+    tt_sem_inc     (&B, 0x9000u, 0x1234u, 2u);
+    uint32_t n = rv_buf_n_words(&A);
+    CHEQ(n, rv_buf_n_words(&B));
+    CHECK(memcmp(rv_buf_data(&A), rv_buf_data(&B), n * 4u) == 0);
+    PASS();
+}
+TH_REG("tensix", cb_push_is_sem_inc);
+
+static void cb_wait_front_is_wait_ge(void)
+{
+    static rv_buf_t A;
+    rv_buf_init(&A);
+    rv_buf_init(&B);
+    tt_cb_wait_front(&A, 0x9000u, 3u);
+    tt_sem_wait_ge  (&B, 0x9000u, 3u);
+    uint32_t n = rv_buf_n_words(&A);
+    CHEQ(n, rv_buf_n_words(&B));
+    CHECK(memcmp(rv_buf_data(&A), rv_buf_data(&B), n * 4u) == 0);
+    PASS();
+}
+TH_REG("tensix", cb_wait_front_is_wait_ge);

--- a/tests/tcbsync.c
+++ b/tests/tcbsync.c
@@ -90,19 +90,37 @@ static void cb_push_is_sem_inc(void)
 }
 TH_REG("tensix", cb_push_is_sem_inc);
 
-static void cb_wait_front_is_wait_ge(void)
+static void cb_wait_front_is_acquire(void)
 {
     static rv_buf_t A;
     rv_buf_init(&A);
     rv_buf_init(&B);
+    /* wait_front acquires a credit: spin until >= n, then atomic -= n. */
     tt_cb_wait_front(&A, 0x9000u, 3u);
-    tt_sem_wait_ge  (&B, 0x9000u, 3u);
+    tt_sem_acquire  (&B, 0x9000u, 3u);
     uint32_t n = rv_buf_n_words(&A);
     CHEQ(n, rv_buf_n_words(&B));
     CHECK(memcmp(rv_buf_data(&A), rv_buf_data(&B), n * 4u) == 0);
     PASS();
 }
-TH_REG("tensix", cb_wait_front_is_wait_ge);
+TH_REG("tensix", cb_wait_front_is_acquire);
+
+/* ---- acquire = wait_ge followed by an atomic decrement ---- */
+
+static void acquire_waits_then_decrements(void)
+{
+    static rv_buf_t A;
+    rv_buf_init(&A);
+    rv_buf_init(&B);
+    tt_sem_acquire(&A, 0x9000u, 1u);
+    tt_sem_wait_ge(&B, 0x9000u, 1u);
+    tt_sem_inc    (&B, 0x9000u, 0u, 0xFFFFFFFFu);   /* atomic -1 */
+    uint32_t n = rv_buf_n_words(&A);
+    CHEQ(n, rv_buf_n_words(&B));
+    CHECK(memcmp(rv_buf_data(&A), rv_buf_data(&B), n * 4u) == 0);
+    PASS();
+}
+TH_REG("tensix", acquire_waits_then_decrements);
 
 /* ---- compute weave brackets the issue stream with the CB handshake ---- */
 
@@ -125,6 +143,7 @@ static void compute_weave_brackets_issue(void)
     s.in_free_lo    = 0x9000u;
     s.out_free_addr = 0xB100u;
     s.out_recv_lo   = 0x9100u;
+    s.out_depth     = 2u;
 
     rv_buf_init(&B);
     CHEQ(tensix_emit_compute_rv(m, &B, &s), BC_OK);

--- a/tests/trv_elf.c
+++ b/tests/trv_elf.c
@@ -35,11 +35,9 @@ static uint32_t rd32(uint32_t off)
          | ((uint32_t)rd[off + 3] << 24);
 }
 
-/* Build a trivial three-instruction kernel:
- *   addi a0, zero, 42
- *   addi a1, zero, 7
- *   add  a0, a0, a1
- * No store, just enough body for the ELF emitter to write. */
+/* Build a trivial three-instruction kernel (addi a0, zero, 42; addi a1,
+ * zero, 7; add a0, a0, a1), with no store, just enough body for the ELF
+ * emitter to write. */
 
 static void build_kernel(void)
 {

--- a/tests/trv_enc.c
+++ b/tests/trv_enc.c
@@ -6,14 +6,10 @@
 #include "rv_enc.h"
 
 /* ---- R-type ALU ---- */
-/*
- * add x0, x0, x0 = 0x00000033
- *   opcode=0x33, funct3=0, funct7=0, rs1=rs2=rd=0
+/* add x0, x0, x0 is 0x00000033: opcode 0x33 with every field zero.
  * add x5, x6, x7 = 0x00730333... wait, let's compute properly:
- *   bits: funct7=0000000 rs2=00111 rs1=00110 funct3=000 rd=00101 opcode=0110011
- *       = 0 << 25 | 7 << 20 | 6 << 15 | 0 << 12 | 5 << 7 | 0x33
- *       = 0x00000000 | 0x00700000 | 0x00030000 | 0x0 | 0x00000280 | 0x33
- *       = 0x007302B3 */
+ * funct7=0, rs2=7, rs1=6, funct3=0, rd=5, opcode=0x33 packs to
+ * (7<<20) | (6<<15) | (5<<7) | 0x33 = 0x007302B3. */
 
 static void rv_add_zero(void)
 {
@@ -29,11 +25,8 @@ static void rv_add_x5_x6_x7(void)
 }
 TH_REG("rv_enc", rv_add_x5_x6_x7);
 
-/* sub differs from add only in funct7 bit 5 (funct7 = 0x20).
- * sub x5, x6, x7:
- *   = 0x20 << 25 | 7 << 20 | 6 << 15 | 0 << 12 | 5 << 7 | 0x33
- *   = 0x40000000 | 0x00700000 | 0x00030000 | 0 | 0x280 | 0x33
- *   = 0x407302B3 */
+/* sub differs from add only in funct7 bit 5 (funct7 = 0x20), so
+ * sub x5, x6, x7 = 0x40000000 | 0x007302B3 = 0x407302B3. */
 
 static void rv_sub_x5_x6_x7(void)
 {
@@ -54,11 +47,8 @@ static void rv_sra_vs_srl(void)
 TH_REG("rv_enc", rv_sra_vs_srl);
 
 /* ---- I-type ALU ---- */
-/*
- * addi x1, x0, 5:
- *   imm[11:0]=000000000101, rs1=0, funct3=0, rd=1, opcode=0010011
- *   = 5 << 20 | 0 << 15 | 0 << 12 | 1 << 7 | 0x13
- *   = 0x00500000 | 0 | 0 | 0x80 | 0x13 = 0x00500093 */
+/* addi x1, x0, 5: imm=5 in bits [31:20], rd=1, opcode 0x13, giving
+ * (5<<20) | (1<<7) | 0x13 = 0x00500093. */
 
 static void rv_addi_pos(void)
 {
@@ -67,11 +57,9 @@ static void rv_addi_pos(void)
 }
 TH_REG("rv_enc", rv_addi_pos);
 
-/* Negative immediate sign-extends through the 12-bit field.
- * addi x1, x0, -1:
- *   imm = -1 = 0xFFFFFFFF, masked to 12 bits = 0xFFF
- *   = 0xFFF << 20 | 0 | 0 | 1 << 7 | 0x13
- *   = 0xFFF00000 | 0x80 | 0x13 = 0xFFF00093 */
+/* Negative immediates sign-extend through the 12-bit field. For
+ * addi x1, x0, -1 the imm masks to 0xFFF, so (0xFFF<<20) | (1<<7) | 0x13
+ * = 0xFFF00093. */
 
 static void rv_addi_neg(void)
 {
@@ -80,10 +68,8 @@ static void rv_addi_neg(void)
 }
 TH_REG("rv_enc", rv_addi_neg);
 
-/* SLLI uses a 5-bit shamt in bits[24:20], funct7=0x00.
- * slli x1, x2, 4:
- *   = 0 << 25 | 4 << 20 | 2 << 15 | 1 << 12 | 1 << 7 | 0x13
- *   = 0x00400000 | 0x00010000 | 0x1000 | 0x80 | 0x13 = 0x00411093 */
+/* SLLI uses a 5-bit shamt in bits [24:20] with funct7=0x00, so
+ * slli x1, x2, 4 = (4<<20) | (2<<15) | (1<<12) | (1<<7) | 0x13 = 0x00411093. */
 
 static void rv_slli_basic(void)
 {
@@ -104,11 +90,8 @@ static void rv_srai_basic(void)
 TH_REG("rv_enc", rv_srai_basic);
 
 /* ---- Loads ---- */
-/*
- * lw x1, 0(x2):
- *   imm=0, rs1=2, funct3=2 (LW), rd=1, opcode=0x03
- *   = 0 << 20 | 2 << 15 | 2 << 12 | 1 << 7 | 0x03
- *   = 0x10000 | 0x2000 | 0x80 | 0x03 = 0x00012083 */
+/* lw x1, 0(x2): rs1=2, funct3=2 (LW), rd=1, opcode 0x03, giving
+ * (2<<15) | (2<<12) | (1<<7) | 0x03 = 0x00012083. */
 
 static void rv_lw_basic(void)
 {
@@ -117,11 +100,8 @@ static void rv_lw_basic(void)
 }
 TH_REG("rv_enc", rv_lw_basic);
 
-/* lw with non-zero offset, sign-extended:
- * lw x1, -4(x2):
- *   imm = -4, masked to 12 bits = 0xFFC
- *   = 0xFFC << 20 | 2 << 15 | 2 << 12 | 1 << 7 | 0x03
- *   = 0xFFC00000 | 0x10000 | 0x2000 | 0x80 | 0x03 = 0xFFC12083 */
+/* lw with a non-zero, sign-extended offset: for lw x1, -4(x2) the
+ * imm masks to 0xFFC, giving 0xFFC00000 | 0x00012083 = 0xFFC12083. */
 
 static void rv_lw_neg_off(void)
 {
@@ -131,12 +111,9 @@ static void rv_lw_neg_off(void)
 TH_REG("rv_enc", rv_lw_neg_off);
 
 /* ---- Stores ---- */
-/*
- * sw x2, 0(x1):
- *   imm=0, rs2=2, rs1=1, funct3=2, opcode=0x23
- *   no scrambling matters here since imm=0
- *   = 0 << 25 | 2 << 20 | 1 << 15 | 2 << 12 | 0 << 7 | 0x23
- *   = 0x00200000 | 0x8000 | 0x2000 | 0x23 = 0x0020A023 */
+/* sw x2, 0(x1): rs2=2, rs1=1, funct3=2, opcode 0x23, and no S-type
+ * bit-scrambling matters since imm=0, giving (2<<20) | (1<<15) | (2<<12)
+ * | 0x23 = 0x0020A023. */
 
 static void rv_sw_basic(void)
 {
@@ -145,11 +122,9 @@ static void rv_sw_basic(void)
 }
 TH_REG("rv_enc", rv_sw_basic);
 
-/* sw with scrambled immediate verifies the S-type bit split.
- * sw x2, 24(x1):  (24 = 0b011000)
- *   imm[11:5] = 0b0000000, imm[4:0] = 0b11000
- *   = 0 << 25 | 2 << 20 | 1 << 15 | 2 << 12 | 0x18 << 7 | 0x23
- *   = 0 | 0x200000 | 0x8000 | 0x2000 | 0xC00 | 0x23 = 0x0020AC23 */
+/* sw with a scrambled immediate verifies the S-type bit split. For
+ * sw x2, 24(x1), 24 splits to imm[11:5]=0 and imm[4:0]=0x18, so
+ * (2<<20) | (1<<15) | (2<<12) | (0x18<<7) | 0x23 = 0x0020AC23. */
 
 static void rv_sw_off24(void)
 {
@@ -159,10 +134,8 @@ static void rv_sw_off24(void)
 TH_REG("rv_enc", rv_sw_off24);
 
 /* ---- Branches ---- */
-/*
- * beq x0, x0, 0:
- *   opcode=0x63, funct3=0, rs1=0, rs2=0, all immediate bits 0
- *   = 0x00000063 */
+/* beq x0, x0, 0: opcode 0x63, funct3 0, all registers and immediate
+ * bits zero, giving 0x00000063. */
 
 static void rv_beq_zero(void)
 {
@@ -171,10 +144,8 @@ static void rv_beq_zero(void)
 }
 TH_REG("rv_enc", rv_beq_zero);
 
-/* beq x5, x6, 8:  offset 8 = 0b01000
- *   imm[12]=0, imm[11]=0, imm[10:5]=0, imm[4:1]=0b0100, imm[0]=0 (ignored)
- *   = 0 << 31 | 0 << 25 | 6 << 20 | 5 << 15 | 0 << 12 | 4 << 8 | 0 << 7 | 0x63
- *   = 0x00600000 | 0x00028000 | 0 | 0x400 | 0 | 0x63 = 0x00628463 */
+/* beq x5, x6, 8: offset 8 puts imm[4:1]=0b0100 into bits [11:8], so
+ * (6<<20) | (5<<15) | (4<<8) | 0x63 = 0x00628463. */
 
 static void rv_beq_off8(void)
 {
@@ -183,11 +154,9 @@ static void rv_beq_off8(void)
 }
 TH_REG("rv_enc", rv_beq_off8);
 
-/* Negative branch tests the sign bit landing in inst[31].
- * beq x0, x0, -4: offset = -4 in 13-bit field = 0x1FFC
- *   imm[12]=1, imm[11]=1, imm[10:5]=0b111111, imm[4:1]=0b1110
- *   = 1 << 31 | 0x3F << 25 | 0 | 0 | 0 | 0xE << 8 | 1 << 7 | 0x63
- *   = 0x80000000 | 0x7E000000 | 0xE00 | 0x80 | 0x63 = 0xFE000EE3 */
+/* A negative branch tests the sign bit landing in inst[31]. Offset -4
+ * is 0x1FFC in the 13-bit field, scattering to 0x80000000 | 0x7E000000
+ * | 0xE00 | 0x80 | 0x63 = 0xFE000EE3. */
 
 static void rv_beq_back(void)
 {
@@ -197,9 +166,7 @@ static void rv_beq_back(void)
 TH_REG("rv_enc", rv_beq_back);
 
 /* ---- Jumps and uppers ---- */
-/*
- * jal x1, 0:  opcode 0x6F, rd=1, offset=0
- *   = 0 | 0 | 0 | 1 << 7 | 0x6F = 0x000000EF */
+/* jal x1, 0: opcode 0x6F, rd=1, offset 0, giving (1<<7) | 0x6F = 0x000000EF. */
 
 static void rv_jal_zero(void)
 {
@@ -208,9 +175,8 @@ static void rv_jal_zero(void)
 }
 TH_REG("rv_enc", rv_jal_zero);
 
-/* lui x1, 0x12345:
- *   imm[31:12] = 0x12345, rd=1, opcode=0x37
- *   = 0x12345 << 12 | 1 << 7 | 0x37 = 0x12345000 | 0xB7 = 0x123450B7 */
+/* lui x1, 0x12345: imm[31:12]=0x12345, rd=1, opcode 0x37, giving
+ * 0x12345000 | 0xB7 = 0x123450B7. */
 
 static void rv_lui_basic(void)
 {
@@ -231,11 +197,8 @@ static void rv_auipc_vs_lui(void)
 TH_REG("rv_enc", rv_auipc_vs_lui);
 
 /* ---- M extension ---- */
-/*
- * mul x5, x6, x7:
- *   funct7=0x01, rs2=7, rs1=6, funct3=0, rd=5, opcode=0x33
- *   = 0x01 << 25 | 7 << 20 | 6 << 15 | 0 << 12 | 5 << 7 | 0x33
- *   = 0x02000000 | 0x700000 | 0x30000 | 0x280 | 0x33 = 0x027302B3 */
+/* mul x5, x6, x7: funct7=0x01, rs2=7, rs1=6, rd=5, opcode 0x33, giving
+ * 0x02000000 | (7<<20) | (6<<15) | (5<<7) | 0x33 = 0x027302B3. */
 
 static void rv_mul_basic(void)
 {
@@ -297,9 +260,8 @@ static void rv_nop_canonical(void)
 }
 TH_REG("rv_enc", rv_nop_canonical);
 
-/* fence rw, rw = 0x0FF0000F (pred=0xF, succ=0xF)
- *   = 0xF << 24 | 0xF << 20 | 0x0F
- *   = 0x0F000000 | 0xF00000 | 0x0F = 0x0FF0000F */
+/* fence rw, rw with pred=0xF and succ=0xF gives (0xF<<24) | (0xF<<20)
+ * | 0x0F = 0x0FF0000F. */
 
 static void rv_fence_rwrw(void)
 {

--- a/tests/trv_isel.c
+++ b/tests/trv_isel.c
@@ -223,17 +223,12 @@ static void rv_isel_unsupported(void)
 TH_REG("rv_enc", rv_isel_unsupported);
 
 /* ---- THREAD_ID etc. lower to LW from L1 runtime args ---- */
-/*
- * Each coordinate intrinsic emits two instructions: LUI to
- * materialise the runtime args base into t1, then LW from the
- * appropriate offset in that region. We check both pieces appear
- * in the output rather than trying to find a particular slot in
- * the buffer, because the surrounding code can shift if other
- * lowerings change. The expected encoding is what the spec says
- * the launcher will write into.
- *
- * No stub: the kernel actually reads from L1; what's IN that L1
- * slot is the launcher's responsibility, not the compiler's. */
+/* Each coordinate intrinsic emits two instructions: a LUI to materialise
+ * the runtime-args base into t1, then a LW from the right offset. We check
+ * both pieces appear rather than hunting a particular buffer slot, since
+ * surrounding code shifts as other lowerings change. No stub here: the
+ * kernel really reads from L1, and what's in that slot is the launcher's
+ * job, not the compiler's. */
 static void rv_isel_thread_id_x_via_l1(void)
 {
     build_bir_add();
@@ -533,16 +528,10 @@ static void rv_isel_icmp_ult(void)
 TH_REG("rv_enc", rv_isel_icmp_ult);
 
 /* ---- load_imm32: small constant ---- */
-/*
- * Below ADDI's 12-bit signed range, materialisation should be a
- * single ADDI from x0. Just above, it should be LUI followed by a
- * negative ADDI when the low half's high bit is set, and LUI
- * followed by a positive ADDI otherwise.
- *
- * We build a BIR module that produces "return c" for a chosen
- * constant c, then walk the emitted instructions and check the
- * mantissa.
- */
+/* Below ADDI's 12-bit signed range, materialisation is a single ADDI
+ * from x0. Above it, it's a LUI plus an ADDI, negative when the low
+ * half's high bit is set and positive otherwise. We build a "return c"
+ * module for a chosen constant and walk the emitted instructions. */
 static void build_bir_return_const(int32_t v)
 {
     memset(&fake_bir, 0, sizeof(fake_bir));
@@ -669,11 +658,10 @@ TH_REG("rv_enc", rv_isel_cast_id_bitcast);
 
 /* ---- Width conversions ---- */
 /*
- * ZEXT i8 -> i32 should be SLLI 24, SRLI 24 — that's the
- * canonical pattern for clearing the high bits without a mask
- * that doesn't fit in ANDI. SEXT i8 -> i32 differs only in
- * using SRAI instead of SRLI to sign-extend. TRUNC i32 -> i8
- * is the same SLLI/SRLI pair as ZEXT (clear the high bits). */
+ * ZEXT i8 -> i32 should be SLLI 24 then SRLI 24, the canonical pattern
+ * for clearing the high bits without a mask that won't fit in ANDI. SEXT
+ * i8 -> i32 differs only in using SRAI instead of SRLI to sign-extend, and
+ * TRUNC i32 -> i8 is the same SLLI/SRLI pair as ZEXT. */
 
 static void build_bir_zext_i8_to_i32(void)
 {
@@ -742,18 +730,12 @@ TH_REG("rv_enc", rv_isel_sext_i8);
  *       *out = helper(a, b);
  *   }
  *
- * helper is function 1, kern is function 0 (emitted first because
- * function 0 is the entry point). BIR_CALL inside kern targets
- * function 1; the JAL offset gets filled in after both functions
- * have been laid out in the code buffer.
- *
- * What we check:
- *   - rv_isel_module returns OK
- *   - Both function prologues appear in the buffer (we look for
- *     two `sw ra, 0(sp)` instructions, one per function)
- *   - At least one JAL with a positive offset exists (the call
- *     from kern to helper, since helper is laid out after kern)
- */
+ * helper is function 1 and kern is function 0, emitted first because
+ * function 0 is the entry point. BIR_CALL inside kern targets function 1,
+ * and the JAL offset is filled in once both functions are laid out. We
+ * check that rv_isel_module returns OK, that both prologues appear (two
+ * `sw ra, 0(sp)`, one per function), and that at least one JAL with a
+ * positive offset exists for the forward call from kern to helper. */
 static void build_bir_kern_calls_helper(void)
 {
     memset(&fake_bir, 0, sizeof(fake_bir));
@@ -1016,13 +998,9 @@ static void rv_isel_br_forward_and_backward(void)
 TH_REG("rv_enc", rv_isel_br_forward_and_backward);
 
 /* ---- BR_COND emits BNE + JAL ---- */
-/*
- * `if (cond) goto X; else goto Y;` lowers to:
- *   load cond -> T0
- *   BNE T0, zero, X
- *   JAL zero, Y
- * We construct a two-arm BIR and check both branch flavours
- * appear in the output. */
+/* `if (cond) goto X; else goto Y;` lowers to loading cond into T0, a
+ * BNE T0, zero, X, then a JAL zero, Y. We construct a two-arm BIR and
+ * check both branch flavours appear in the output. */
 static void rv_isel_br_cond_shape(void)
 {
     memset(&fake_bir, 0, sizeof(fake_bir));
@@ -1092,15 +1070,10 @@ static void rv_isel_br_cond_shape(void)
 TH_REG("rv_enc", rv_isel_br_cond_shape);
 
 /* ---- SELECT: BEQ skip + value loads ---- */
-/*
- * cond ? a : b lowers to:
- *   load cond  -> T2
- *   load b     -> T0
- *   BEQ T2, zero, skip past true arm
- *   load a     -> T0
- *   store T0
- * We can't easily verify the exact skip offset without depending
- * on every instruction count downstream, but we can check that a
+/* cond ? a : b lowers to loading cond into T2 and b into T0, a
+ * BEQ T2, zero to skip past the true arm, then loading a into T0 and
+ * storing T0. We can't easily verify the exact skip offset without
+ * depending on every downstream instruction count, but we can check a
  * BEQ appears and the buffer parses past it without unresolved
  * placeholders. */
 static void rv_isel_select_shape(void)
@@ -1122,7 +1095,7 @@ static void rv_isel_select_shape(void)
     fake_bir.blocks[0].first_inst = 0;
     fake_bir.blocks[0].num_insts = 5;
 
-    /* PARAM 0,1,2 — cond, a, b */
+    /* PARAM 0,1,2 (cond, a, b) */
     for (int p = 0; p < 3; p++) {
         fake_bir.insts[p].op = BIR_PARAM;
         fake_bir.insts[p].subop = (uint8_t)p;
@@ -1218,18 +1191,12 @@ TH_REG("rv_enc", rv_isel_param_overflow_refused);
  *
  * Construct a kernel with a 4-int struct (gp_cell_t shape from
  * test_cell_load.cu) and a GEP that accesses field 1. The isel
- * should emit ADDI t0, t0, 4 (the byte offset of field 1, since
- * each preceding field is 4 bytes).
+ * should emit ADDI t0, t0, 4, the byte offset of field 1 since each
+ * preceding field is 4 bytes.
  *
- * The BIR we build:
- *   types: 0=i32, 1=struct{i32,i32,f32,i32}, 2=ptr<global,struct>,
- *          3=ptr<global,i32>, 4=void, 5=f32 (for the struct field)
- *   consts: 0 = i32 const 1
- *   insts: 0 = PARAM 0 (ptr<global,struct>)
- *          1 = GEP base=%0, idx=0 (just the struct pointer)
- *          2 = GEP base=%1, idx=1 (field 1 of struct, i32 mat)
- *          3 = RET void
- */
+ * The BIR uses types 0=i32, 1=struct{i32,i32,f32,i32}, 2=ptr<global,
+ * struct>, 3=ptr<global,i32>, 4=void and 5=f32, one i32 const of 1, and
+ * insts PARAM 0, a no-op GEP on idx 0, a GEP to field 1, then RET void. */
 static void rv_isel_struct_gep_field1(void)
 {
     memset(&fake_bir, 0, sizeof(fake_bir));
@@ -1305,17 +1272,13 @@ TH_REG("rv_enc", rv_isel_struct_gep_field1);
 
 /* ---- type_bytes for nested types ----
  *
- * The size walker has to recurse into ARRAY, VECTOR and STRUCT.
- * We don't expose type_bytes directly, so the test exercises it
- * via a struct GEP that picks a field whose offset depends on
- * a preceding ARRAY field's full size being known.
+ * The size walker has to recurse into ARRAY, VECTOR and STRUCT. We don't
+ * expose type_bytes directly, so the test exercises it via a struct GEP
+ * whose field offset depends on a preceding ARRAY field's full size.
  *
- * Struct: { i8, [4 x i32], i32 }
- *   field 0: i8 at offset 0, size 1
- *   field 1: [4 x i32] starts at 4 (aligned), size 16
- *   field 2: i32 at offset 20, size 4
- * GEP-to-field-2 should produce ADDI 20.
- */
+ * For struct { i8, [4 x i32], i32 } the i8 sits at offset 0, the [4 x i32]
+ * starts at 4 (aligned) with size 16, and the trailing i32 lands at offset
+ * 20, so GEP-to-field-2 should produce ADDI 20. */
 static void rv_isel_struct_gep_with_array(void)
 {
     memset(&fake_bir, 0, sizeof(fake_bir));
@@ -1386,23 +1349,15 @@ TH_REG("rv_enc", rv_isel_struct_gep_with_array);
 
 /* ---- Array-of-struct GEP: stride access (the bug regression) ----
  *
- * Distinct from struct-field GEP: when base AND result pointees
- * are the SAME struct type, the index is a stride multiplier
- * (typically a runtime threadIdx), not a field number. The isel
- * must recognise this and emit a MUL by sizeof(struct), not a
- * struct-field offset lookup.
+ * Distinct from struct-field GEP: when base AND result pointees are the
+ * SAME struct type, the index is a stride multiplier (typically a runtime
+ * threadIdx), not a field number. The isel must recognise this and emit a
+ * MUL by sizeof(struct), not a struct-field offset lookup.
  *
- * Struct: { i32, i32 } -> size 8 bytes
- * BIR:
- *   %0 = PARAM 0 (ptr<global, struct>)
- *   %1 = PARAM 1 (i32 idx, runtime)
- *   %2 = GEP base=%0, idx=%1   (yields ptr<global, struct>, same pointee)
- *   %3 = RET void
- *
- * Expected codegen: load base, load idx, multiply idx by 8, add
- * to base, store. The defining instruction is MUL with elem_size
- * loaded into a register; we look for the LI for the size of 8
- * and the MUL. */
+ * The struct { i32, i32 } is 8 bytes, and the BIR takes a ptr<global,
+ * struct> param and a runtime i32 idx, then GEPs base by idx to yield the
+ * same pointee before RET. The codegen loads base and idx, multiplies idx
+ * by 8 and adds it to base, so we look for the LI of 8 and the MUL. */
 static void rv_isel_array_of_struct_stride(void)
 {
     memset(&fake_bir, 0, sizeof(fake_bir));

--- a/tests/ttdf.c
+++ b/tests/ttdf.c
@@ -415,11 +415,9 @@ static void tdf_build_then_lower(void)
 TH_REG("tdf", tdf_build_then_lower);
 
 /* ---- td_tile_bytes returns the right size per dtype ---- */
-/*
- * Wormhole's tile granularity is 32x32. At fp32 that is 4096 bytes,
- * at fp16/bf16 it is 2048. These numbers turn up in NoC alignment
- * arithmetic, in CB depth budgets, and in any future runtime arg
- * computation, so a regression here would ripple everywhere. */
+/* Wormhole tiles are 32x32, so 4096 bytes at fp32 and 2048 at fp16/bf16.
+ * Those numbers feed NoC alignment, CB depth and runtime args, so a
+ * regression here ripples everywhere. */
 
 static void tdf_tile_bytes_fp32(void)
 {
@@ -495,12 +493,8 @@ TH_REG("tdf", tdf_place_budget);
 
 static void tdf_noc_addr_basic(void)
 {
-    /* (x=1, y=2, local=0x1000) ->
-     *   0x1000 | (1<<36) | (2<<42)
-     *   = 0x0000_0000_0000_1000
-     *   | 0x0000_0010_0000_0000
-     *   | 0x0000_0800_0000_0000
-     *   = 0x0000_0810_0000_1000 */
+    /* (x=1, y=2, local=0x1000) packs to 0x1000 | (1<<36) | (2<<42),
+     * which is 0x0000081000001000. */
     CHEQ(td_noc_addr(1, 2, 0x1000ull), 0x0000081000001000ull);
     PASS();
 }

--- a/tests/ttdf.c
+++ b/tests/ttdf.c
@@ -19,6 +19,14 @@ static int bufs_eq(const rv_buf_t *a, const rv_buf_t *b)
     return memcmp(rv_buf_data(a), rv_buf_data(b), n * 4u) == 0;
 }
 
+static int has_word(const rv_buf_t *b, uint32_t w)
+{
+    uint32_t n = rv_buf_n_words(b);
+    const uint32_t *d = rv_buf_data(b);
+    for (uint32_t i = 0; i < n; i++) if (d[i] == w) return 1;
+    return 0;
+}
+
 /* bir_module_t is a multi-megabyte arena and absolutely will not fit
  * on the stack. We never dereference this in the lowering, the
  * lowering just compares pointers, so one BSS sentinel is enough
@@ -745,3 +753,47 @@ static void tdf_emit_cb_rejects_noc(void)
     PASS();
 }
 TH_REG("tdf", tdf_emit_cb_rejects_noc);
+
+/* ---- reader loop: DRAM -> L1, read barrier, back-jump ---- */
+
+static void tdf_reader_loop_shape(void)
+{
+    rv_buf_init(&EA);
+    CHEQ(td_emit_dma_loop(&EA, /*is_write=*/0,
+                          /*dram_slot=*/0, /*ntiles_slot=*/1,
+                          /*l1_buf=*/0x8100u, /*depth=*/2u,
+                          /*dram_mid=*/0u, /*l1_mid=*/0u,
+                          /*tile_bytes=*/4096u,
+                          /*recv=*/0xA100u, /*free=*/0xA104u), BC_OK);
+    uint32_t n = rv_buf_n_words(&EA);
+    CHECK(n > 40u);
+    /* DRAM(a3) -> L1(a4): target-low from a3, return-low from a4. */
+    CHECK(has_word(&EA, rv_sw(RV_A3, RV_T0, 0x00)));
+    CHECK(has_word(&EA, rv_sw(RV_A4, RV_T0, 0x0C)));
+    /* read barrier polls RD_REQ_SENT (0x14) vs RD_RESP_RECEIVED (0x08). */
+    CHECK(has_word(&EA, rv_lw(RV_T1, RV_T0, 0x14)));
+    CHECK(has_word(&EA, rv_lw(RV_T2, RV_T0, 0x08)));
+    /* loop closes with a back jump: jal zero, <negative>. */
+    uint32_t last = rv_buf_data(&EA)[n - 1u];
+    CHEQ(last & 0x7fu, 0x6fu);          /* JAL opcode      */
+    CHEQ((last >> 7) & 0x1fu, 0u);      /* rd == zero      */
+    PASS();
+}
+TH_REG("tdf", tdf_reader_loop_shape);
+
+/* ---- writer loop: L1 -> DRAM, write-ack barrier ---- */
+
+static void tdf_writer_loop_shape(void)
+{
+    rv_buf_init(&EA);
+    CHEQ(td_emit_dma_loop(&EA, /*is_write=*/1,
+                          0, 1, 0x8100u, 2u, 0u, 0u, 4096u,
+                          0xA100u, 0xA104u), BC_OK);
+    /* L1(a4) -> DRAM(a3): target-low from a4, return-low from a3. */
+    CHECK(has_word(&EA, rv_sw(RV_A4, RV_T0, 0x00)));
+    CHECK(has_word(&EA, rv_sw(RV_A3, RV_T0, 0x0C)));
+    /* write barrier polls WR_ACK_RECEIVED (0x04), reader's never does. */
+    CHECK(has_word(&EA, rv_lw(RV_T2, RV_T0, 0x04)));
+    PASS();
+}
+TH_REG("tdf", tdf_writer_loop_shape);

--- a/tests/ttdf.c
+++ b/tests/ttdf.c
@@ -3,8 +3,21 @@
 
 #include "tharns.h"
 #include "tdf.h"
+#include "noc.h"
+#include "rv_enc.h"
 
 static char obuf[TH_BUFSZ];
+
+/* CB-arc emit comparison buffers. Each rv_buf_t is 16 KiB, so keep them in
+ * BSS rather than on MinGW's lazily-committed stack. */
+static rv_buf_t EA, EB;
+
+static int bufs_eq(const rv_buf_t *a, const rv_buf_t *b)
+{
+    uint32_t n = rv_buf_n_words(a);
+    if (n != rv_buf_n_words(b)) return 0;
+    return memcmp(rv_buf_data(a), rv_buf_data(b), n * 4u) == 0;
+}
 
 /* bir_module_t is a multi-megabyte arena and absolutely will not fit
  * on the stack. We never dereference this in the lowering, the
@@ -666,3 +679,69 @@ static void tdf_region_overflow(void)
     PASS();
 }
 TH_REG("tdf", tdf_region_overflow);
+
+/* ---- CB-arc emit lowers each kind to the right primitive at placed addrs ---- */
+
+static void tdf_emit_cb_arcs(void)
+{
+    td_init(&M, TD_TGT_TENSIX);
+    uint16_t rdr = td_mkrgn(&M, TD_RG_RDR);
+    uint16_t cmp = td_mkrgn(&M, TD_RG_CMP);
+    td_tag_t  tag = tile_f32(32, 32, TD_LAY_INTRL);
+    uint16_t  ch  = td_link(&M, rdr, cmp, tag, /*depth=*/2);
+    CHEQ(td_place_l1(&M), BC_OK);
+
+    /* counters sit in the FIFO header right after the tile-data buffer. */
+    uint32_t data_b = td_tile_bytes(M.chans[ch].tag) * (uint32_t)M.chans[ch].depth;
+    uint32_t recv   = M.chans[ch].l1_off + data_b;
+    uint32_t freec  = recv + 4u;
+    /* producer and consumer share the tile (coords 0,0), so the NoC address
+     * the atomic targets equals the bare L1 address. */
+
+    /* RSV -> reserve_back(free): producer waits on the free counter. */
+    uint16_t a_rsv = td_mkarc(&M, rdr, TD_AR_RSV, ch, 1, 0);
+    rv_buf_init(&EA); rv_buf_init(&EB);
+    CHEQ(td_emit_cb_arc(&M, &M.arcs[a_rsv], &EA), BC_OK);
+    tt_cb_reserve_back(&EB, freec, 1);
+    CHECK(bufs_eq(&EA, &EB));
+
+    /* WAIT -> wait_front(recv): consumer waits on the recv counter. */
+    uint16_t a_wait = td_mkarc(&M, cmp, TD_AR_WAIT, ch, 1, 0);
+    rv_buf_init(&EA); rv_buf_init(&EB);
+    CHEQ(td_emit_cb_arc(&M, &M.arcs[a_wait], &EA), BC_OK);
+    tt_cb_wait_front(&EB, recv, 1);
+    CHECK(bufs_eq(&EA, &EB));
+
+    /* PUSH -> sem_inc(recv): producer bumps the consumer's recv counter. */
+    uint16_t a_push = td_mkarc(&M, rdr, TD_AR_PUSH, ch, 1, 0);
+    rv_buf_init(&EA); rv_buf_init(&EB);
+    CHEQ(td_emit_cb_arc(&M, &M.arcs[a_push], &EA), BC_OK);
+    tt_cb_push_back(&EB, recv, 0, 1);
+    CHECK(bufs_eq(&EA, &EB));
+
+    /* POP -> sem_inc(free): consumer bumps the producer's free counter. */
+    uint16_t a_pop = td_mkarc(&M, cmp, TD_AR_POP, ch, 1, 0);
+    rv_buf_init(&EA); rv_buf_init(&EB);
+    CHEQ(td_emit_cb_arc(&M, &M.arcs[a_pop], &EA), BC_OK);
+    tt_cb_pop_front(&EB, freec, 0, 1);
+    CHECK(bufs_eq(&EA, &EB));
+    PASS();
+}
+TH_REG("tdf", tdf_emit_cb_arcs);
+
+/* ---- the CB emitter refuses NoC arcs (those are emitted elsewhere) ---- */
+
+static void tdf_emit_cb_rejects_noc(void)
+{
+    td_init(&M, TD_TGT_TENSIX);
+    uint16_t rdr = td_mkrgn(&M, TD_RG_RDR);
+    uint16_t cmp = td_mkrgn(&M, TD_RG_CMP);
+    td_tag_t  tag = tile_f32(32, 32, TD_LAY_INTRL);
+    uint16_t  ch  = td_link(&M, rdr, cmp, tag, 2);
+    td_place_l1(&M);
+    uint16_t a_rd = td_mkarc(&M, rdr, TD_AR_RD, ch, 1, 0);
+    rv_buf_init(&EA);
+    CHEQ(td_emit_cb_arc(&M, &M.arcs[a_rd], &EA), BC_ERR_TDF);
+    PASS();
+}
+TH_REG("tdf", tdf_emit_cb_rejects_noc);

--- a/tests/ttmc.c
+++ b/tests/ttmc.c
@@ -1,0 +1,182 @@
+/* ttmc.c -- Tensix machine-code emit.
+ *
+ * tensix_emit_binary writes raw 32-bit Tensix words and tensix_emit_ttinsn
+ * writes the same words rol-2 encoded for the baby RISC-V push. Neither had a
+ * byte-level test; they were only ever checked by hand through ttas and Kahu,
+ * so a codegen change could shift an encoding while every unit test stayed
+ * green. These build a small module, emit it to a temp file, read it back
+ * little-endian and lock what those tools confirmed, needing neither of them so
+ * it runs anywhere. emit_stream wraps the words in a sync bracket that emit.c
+ * calls provisional, so the checks stay bracket-agnostic. */
+
+#include "tharns.h"
+#include "tensix.h"
+
+/* ~20 MB of minst arena and code buffer, so it lives in BSS rather than on
+ * MinGW's lazy stack. Shared: each test sets num_minsts and the slots it uses. */
+static tt_module_t TT;
+
+#define MAXW 64
+#define TMP_BIN "ttmc_tmp.bin"
+#define TMP_TTI "ttmc_tmp.ttinsn"
+
+/* Zero a slot and set its opcode. With operands NONE and num_uses 0 encode_inst
+ * returns exactly hw_opcode << 24 for any format, which the goldens rely on. */
+static void set_op(uint32_t i, uint16_t op)
+{
+    memset(&TT.minsts[i], 0, sizeof(tt_minst_t));
+    TT.minsts[i].op = op;
+}
+
+static void set_imm(uint32_t i, int slot, int32_t v)
+{
+    TT.minsts[i].operands[slot].kind = TT_MOP_IMM;
+    TT.minsts[i].operands[slot].imm  = v;
+}
+
+/* Read a little-endian 32-bit word stream back off disk. */
+static int read_words(const char *path, uint32_t *out, int max)
+{
+    FILE *fp = fopen(path, "rb");
+    if (!fp) return -1;
+    int n = 0;
+    uint8_t b[4];
+    while (n < max && fread(b, 1, 4, fp) == 4) {
+        out[n++] = (uint32_t)b[0]        | ((uint32_t)b[1] << 8)
+                 | ((uint32_t)b[2] << 16) | ((uint32_t)b[3] << 24);
+    }
+    fclose(fp);
+    return n;
+}
+
+static uint32_t rol2(uint32_t w) { return (w << 2) | (w >> 30); }
+
+static int has_word(const uint32_t *w, int n, uint32_t t)
+{
+    for (int i = 0; i < n; i++) if (w[i] == t) return 1;
+    return 0;
+}
+
+/* Count real instructions, everything below the sync opcode range where the
+ * bracket lives, so we can prove the pseudo-op went without counting the bracket. */
+static int n_compute(const uint32_t *w, int n)
+{
+    int c = 0;
+    for (int i = 0; i < n; i++) if ((w[i] >> 24) < 0xA0u) c++;
+    return c;
+}
+
+/* One instruction per encoding format with operands zero, so each word is just
+ * its opcode byte, and a pseudo-op in the middle that must be dropped. */
+static void ttmc_bin_opcodes(void)
+{
+    uint32_t k = 0;
+    set_op(k++, TT_SFPNOP);      /* 0x02, FMT_C */
+    set_op(k++, TT_SFPMAD);      /* 0x84, FMT_A */
+    set_op(k++, TT_SFPSETCC);    /* 0x7B, FMT_B */
+    set_op(k++, TT_PSEUDO_COPY); /* skipped: no hardware opcode */
+    set_op(k++, TT_SFPWNOP);     /* 0x8F, FMT_C */
+    TT.num_minsts = k;
+
+    CHEQ(tensix_emit_binary(&TT, TMP_BIN), BC_OK);
+    uint32_t w[MAXW];
+    int n = read_words(TMP_BIN, w, MAXW);
+    remove(TMP_BIN);
+    CHECK(n > 0);
+
+    /* four real compute words, the pseudo-op dropped */
+    CHEQ(n_compute(w, n), 4);
+    CHECK(has_word(w, n, 0x02000000u));  /* sfpnop   */
+    CHECK(has_word(w, n, 0x84000000u));  /* sfpmad   */
+    CHECK(has_word(w, n, 0x7B000000u));  /* sfpsetcc */
+    CHECK(has_word(w, n, 0x8F000000u));  /* sfpwnop  */
+    PASS();
+}
+TH_REG("ttmc", ttmc_bin_opcodes);
+
+/* The baby core pushes each Tensix word through a custom instruction encoded as
+ * the word rol-2'd, so both emitters must agree word-for-word under rol2. */
+static void ttmc_ttinsn_is_rol2(void)
+{
+    uint32_t k = 0;
+    set_op(k++, TT_SFPNOP);
+    set_op(k++, TT_SFPMOV);
+    set_op(k++, TT_SFPADD);
+    set_op(k++, TT_SFPMUL);
+    set_op(k++, TT_SFPLOADI);
+    TT.num_minsts = k;
+
+    CHEQ(tensix_emit_binary(&TT, TMP_BIN), BC_OK);
+    CHEQ(tensix_emit_ttinsn(&TT, TMP_TTI), BC_OK);
+    uint32_t bin[MAXW], tti[MAXW];
+    int nb = read_words(TMP_BIN, bin, MAXW);
+    int nt = read_words(TMP_TTI, tti, MAXW);
+    remove(TMP_BIN);
+    remove(TMP_TTI);
+
+    CHECK(nb > 0);
+    CHEQ(nt, nb);
+    for (int i = 0; i < nb; i++)
+        CHEQX(tti[i], rol2(bin[i]));
+    PASS();
+}
+TH_REG("ttmc", ttmc_ttinsn_is_rol2);
+
+/* rol-2 only round-trips because every real opcode is below 0xC0000000, leaving
+ * the top two bits free. Check the ceiling holds and ror-2 restores each word. */
+static void ttmc_ttinsn_reversible(void)
+{
+    uint32_t k = 0;
+    set_op(k++, TT_SFPLOAD);
+    set_op(k++, TT_SFPSTORE);
+    set_op(k++, TT_SFPMAD);
+    set_op(k++, TT_SFPXOR);   /* 0x8D, one of the higher opcodes */
+    TT.num_minsts = k;
+
+    CHEQ(tensix_emit_binary(&TT, TMP_BIN), BC_OK);
+    CHEQ(tensix_emit_ttinsn(&TT, TMP_TTI), BC_OK);
+    uint32_t bin[MAXW], tti[MAXW];
+    int nb = read_words(TMP_BIN, bin, MAXW);
+    int nt = read_words(TMP_TTI, tti, MAXW);
+    remove(TMP_BIN);
+    remove(TMP_TTI);
+
+    CHECK(nb > 0);
+    CHEQ(nt, nb);
+    for (int i = 0; i < nb; i++) {
+        CHECK(bin[i] < 0xC0000000u);               /* ceiling holds    */
+        uint32_t ror2 = (tti[i] >> 2) | (tti[i] << 30);
+        CHEQX(ror2, bin[i]);                        /* round-trips back */
+    }
+    PASS();
+}
+TH_REG("ttmc", ttmc_ttinsn_reversible);
+
+/* Pin the Sync Unit field packing, not just the opcode byte, using values
+ * distinct from the bracket's own sync words so each match is unambiguous. The
+ * bit layouts these goldens encode are the field definitions in emit.c. */
+static void ttmc_sync_fields(void)
+{
+    set_op(0, TT_SEMINIT);                          /* sem_sel 3, init 1, max 2 */
+    set_imm(0, 0, 3); set_imm(0, 1, 1); set_imm(0, 2, 2);
+    set_op(1, TT_SEMWAIT);                          /* sem_sel 4, cond 1, stall 2 */
+    set_imm(1, 0, 4); set_imm(1, 1, 1); set_imm(1, 2, 2);
+    set_op(2, TT_SEMPOST);                          /* sem_sel 5 */
+    set_imm(2, 0, 5);
+    TT.num_minsts = 3;
+
+    CHEQ(tensix_emit_binary(&TT, TMP_BIN), BC_OK);
+    uint32_t w[MAXW];
+    int n = read_words(TMP_BIN, w, MAXW);
+    remove(TMP_BIN);
+    CHECK(n > 0);
+
+    /* seminit: 0xA3 | (max 2 << 20) | (init 1 << 16) | (sem_sel 3 << 2) */
+    CHECK(has_word(w, n, 0xA3000000u | (2u << 20) | (1u << 16) | (3u << 2)));
+    /* semwait: 0xA6 | (stall_res 2 << 15) | (sem_sel 4 << 2) | (cond 1) */
+    CHECK(has_word(w, n, 0xA6000000u | (2u << 15) | (4u << 2) | 1u));
+    /* sempost: 0xA4 | (sem_sel 5 << 2) */
+    CHECK(has_word(w, n, 0xA4000000u | (5u << 2)));
+    PASS();
+}
+TH_REG("ttmc", ttmc_sync_fields);


### PR DESCRIPTION
The Tensix backend has been talking a big game in assembly text for a while now, so this teaches it to actually produce the bytes the hardware eats.

Emit now spits out raw words as a `.bin` that round-trips cleanly through both ttas and Kahu, plus a `.ttinsn` stream in the rol-2 issue encoding the ISA docs ask for (`(w<<2)|(w>>30)`, which is lossless here purely because every opcode we emit has the decency to sit below the top two bits). (Kahu is my in-house GPU disassembler, a sort of llvm-objdump/Ghidra for accelerators, so "round-trips through Kahu" means the bytes we emit disassemble back to the instructions we started with.) On top of that is the sync machinery: the Sync Unit instructions (SEM*/STALLWAIT), a NoC-atomic circular-buffer primitive for producer/consumer handshaking, the NoC register transfer sequence validated against llvm-objdump, and a compute-core weave that wraps the issue stream in a CB handshake. The tdf side lowers sync arcs to baby-core RISC-V and drives a reader/writer tile loop, and the whole lot assembles into three baby-core ELFs sharing one L1 address map, like a very small family that has agreed on the furniture.

Coverage is a new `ttmc.c` golden test: raw opcodes, the rol-2 invariant and that it actually reverses, and the sync-field checks. Suite is green at 300/300 with the usual lone emu skip. The generated `.bin`/`.ttinsn`/`.elf` are gitignored, since nobody needs those in their diff.
