### PR TITLE
RV32 Tensix backend: loadable ELFs, five miscompile fixes, and two frontend crashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,6 @@ CLAUDE.md
 /e2e_rv.elf
 /a_compute.bin
 /a_compute.ttinsn
+
+# Header dependency files from -MMD
+*.d

--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,8 @@ CLAUDE.md
 /kath
 /trunner
 /tdf_*.elf
+
+# Test-run outputs from the Tensix/RV e2e suite
+/e2e_rv.elf
+/a_compute.bin
+/a_compute.ttinsn

--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,4 @@ CLAUDE.md
 
 # Header dependency files from -MMD
 *.d
+tdf_flag_out.txt

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ else
   GCC_ONLY =
 endif
 
-CFLAGS  = -std=c99 -Wall -Wextra -pedantic -O2 \
+CFLAGS  = -std=c99 -MMD -MP -Wall -Wextra -pedantic -O2 \
           -Wshadow -Wstrict-prototypes -Wmissing-prototypes \
           -Wformat=2 -Wundef -Wcast-align -Wnull-dereference \
           -Wconversion -Wold-style-definition \
@@ -59,7 +59,7 @@ $(TARGET): $(OBJECTS)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 # ---- Test Suite ----
-TCFLAGS = -std=c99 -D_POSIX_C_SOURCE=200809L -Wall -Wextra -O0 -g \
+TCFLAGS = -std=c99 -MMD -MP -D_POSIX_C_SOURCE=200809L -Wall -Wextra -O0 -g \
           -Isrc -Isrc/fe -Isrc/ir -Isrc/tdf -Isrc/amdgpu -Isrc/tensix -Isrc/nvidia -Isrc/metal -Isrc/intel -Isrc/triton -Isrc/cpu -Isrc/runtime \
           -Iruntime
 TSRC    = tests/tmain.c tests/tsmoke.c tests/tcomp.c tests/tenc.c \
@@ -116,5 +116,10 @@ runtime/%.o: runtime/%.c
 
 clean:
 	rm -f $(OBJECTS) $(TARGET) $(TARGET).exe trunner trunner.exe $(TOBJS) $(HOSTRT) src/runtime/*.o runtime/*.o
+	rm -f $(OBJECTS:.o=.d) $(TOBJS:.o=.d) $(HOSTRT:.o=.d) src/runtime/*.d runtime/*.d
+
+# Header deps from -MMD. Without these a header edit leaves stale objects
+# linked in and the build silently disagrees with the source.
+-include $(OBJECTS:.o=.d) $(TOBJS:.o=.d) $(HOSTRT:.o=.d)
 
 .PHONY: all clean test

--- a/src/fe/parser.c
+++ b/src/fe/parser.c
@@ -189,11 +189,20 @@ static void reg_tname(parser_t *P, uint32_t off, uint16_t len)
     P->num_tnames++;
 }
 
+/* Text for a name offset. Anonymous struct names are sentinels into anon_buf,
+ * not source positions, so they cannot be added to P->src. */
+static const char *tntxt(const parser_t *P, uint32_t off)
+{
+    return off >= BC_ANON_BASE ? P->anon_buf + (off - BC_ANON_BASE)
+                               : P->src + off;
+}
+
 static int is_reg_type(const parser_t *P, uint32_t off, uint16_t len)
 {
+    const char *q = tntxt(P, off);
     for (int i = 0; i < P->num_tnames; i++) {
         if (P->tnames[i].len == len &&
-            memcmp(P->src + P->tnames[i].off, P->src + off, len) == 0)
+            memcmp(tntxt(P, P->tnames[i].off), q, len) == 0)
             return 1;
     }
     return 0;

--- a/src/fe/preproc.c
+++ b/src/fe/preproc.c
@@ -641,6 +641,19 @@ static uint32_t pp_expand_text(preproc_t *pp,
         return n;
     }
 
+    /* Resume a block comment left open by an earlier line: copy through to its
+     * close before any macro name in the prose can be substituted. */
+    if (pp->in_bcmt) {
+        while (i < in_len && !(in[i] == '*' && i + 1 < in_len && in[i+1] == '/')) {
+            if (olen < out_max) out[olen++] = in[i++]; else i++;
+        }
+        if (i < in_len) {
+            if (olen < out_max) out[olen++] = in[i++]; else i++;
+            if (olen < out_max) out[olen++] = in[i++]; else i++;
+            pp->in_bcmt = 0;
+        }
+    }
+
     while (i < in_len) {
         /* Skip C-style block comments */
         if (in[i] == '/' && i + 1 < in_len && in[i+1] == '*') {
@@ -649,7 +662,12 @@ static uint32_t pp_expand_text(preproc_t *pp,
             while (i < in_len && !(in[i] == '*' && i + 1 < in_len && in[i+1] == '/')) {
                 if (olen < out_max) out[olen++] = in[i++]; else i++;
             }
-            if (i < in_len) { if (olen < out_max) out[olen++] = in[i++]; else i++; }
+            if (i >= in_len) {
+                /* Unterminated on this line; the next one resumes inside it. */
+                pp->in_bcmt = 1;
+                continue;
+            }
+            if (olen < out_max) out[olen++] = in[i++]; else i++;
             if (i < in_len) { if (olen < out_max) out[olen++] = in[i++]; else i++; }
             continue;
         }

--- a/src/fe/preproc.h
+++ b/src/fe/preproc.h
@@ -85,6 +85,10 @@ typedef struct {
     char        line_buf[PP_LINE_BUF];
     char        exp_buf[PP_EXPAND_BUF];
 
+    /* Block comment still open at end of line. Expansion runs per line, so
+     * without this a macro named in comment prose gets substituted. */
+    int         in_bcmt;
+
     /* Errors */
     bc_error_t  errors[BC_MAX_ERRORS];
     int         num_errors;

--- a/src/main.c
+++ b/src/main.c
@@ -288,13 +288,16 @@ static int run_bir_backends(bir_module_t *bir, const backend_cfg_t *cfg)
             fprintf(stderr, "error: BIR module has no functions\n");
             return BC_ERR_TDF;
         }
-        int irc = rv_isel_func(bir, 0u, &rv_code);
+        /* Module, not just function 0: rv_isel_func records call patches but
+         * only rv_isel_module resolves them, so a BIR_CALL through this path
+         * would otherwise keep its placeholder and trap as an illegal insn. */
+        int irc = rv_isel_module(bir, &rv_code);
         if (irc != BC_OK) return irc;
         const char *path = cfg->output_file ? cfg->output_file : "a.elf";
         int erc = rv_elf_write(&rv_code, path);
         if (erc != BC_OK) return erc;
         fprintf(stderr, "wrote %s (%u bytes code, %u instructions)\n",
-                path, rv_buf_pos_bytes(&rv_code),
+                path, rv_buf_nbytes(&rv_code),
                 rv_buf_n_words(&rv_code));
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -436,6 +436,8 @@ static void usage(const char *prog)
         "  -D <name[=val]> Define a preprocessor macro\n"
         "  --amdgpu      Compile to AMDGCN assembly (default: gfx1100)\n"
         "  --amdgpu-bin  Compile to AMDGPU ELF code object (.hsaco)\n"
+        "  --tt-chip C   Tenstorrent part: wormhole or blackhole "
+        "(default blackhole)\n"
         "  --gfx90a      Target CDNA 2 (gfx90a, MI250)\n"
         "  --gfx942      Target CDNA 3 (gfx942, MI300X)\n"
         "  --gfx1030     Target RDNA 2 (gfx1030)\n"
@@ -496,6 +498,7 @@ int main(int argc, char *argv[])
     int no_sched = 0;
     int no_pp = 0;
     int snap_mode = 0;
+    td_chip_t tt_chip = TD_CHIP_BH;
     amd_target_t amd_target = AMD_TARGET_GFX1100;
     uint32_t     amd_elfm  = 0x41;       /* EF_AMDGPU_MACH for exact chip */
     const char  *amd_chip  = "gfx1100";  /* chip string for ELF metadata */
@@ -604,6 +607,13 @@ int main(int argc, char *argv[])
             mode_triton = 1;
         else if (strcmp(argv[i], "--bkhit") == 0)
             nv_bkhit = 1;
+        else if (strcmp(argv[i], "--tt-chip") == 0 && i + 1 < argc) {
+            if (td_pchip(argv[++i], &tt_chip) != BC_OK) {
+                fprintf(stderr, "unknown Tenstorrent chip: %s "
+                                "(want wormhole or blackhole)\n", argv[i]);
+                return 1;
+            }
+        }
         else if (strcmp(argv[i], "--lang") == 0 && i + 1 < argc)
             lang_file = argv[++i];
         else if (strcmp(argv[i], "-o") == 0 && i + 1 < argc)
@@ -654,6 +664,8 @@ int main(int argc, char *argv[])
         usage(argv[0]);
         return 1;
     }
+
+    td_setchip(tt_chip);
 
     /* One cascade for the C99 pipeline, each level meaning "this stage, or
      * anything downstream of it". Four independent lists is how --cpu and then

--- a/src/main.c
+++ b/src/main.c
@@ -657,7 +657,8 @@ int main(int argc, char *argv[])
 
     if (!mode_pp && !mode_lex && !mode_parse && !mode_sema && !mode_ir &&
         !mode_amdgpu && !mode_amdgpu_bin && !mode_tensix && !mode_nvidia &&
-        !mode_metal && !mode_intel && !mode_rv_elf && !mode_cpu && !mode_rv64)
+        !mode_metal && !mode_intel && !mode_rv_elf && !mode_cpu && !mode_rv64 &&
+        !mode_tdf && !mode_tdf_fission)
         mode_parse = 1;
 
     /* ---- HIP NOTES (1 of 2) -------------------------------------------
@@ -896,7 +897,8 @@ int main(int argc, char *argv[])
     }
 
     if (mode_parse || mode_sema || mode_ir || mode_amdgpu || mode_amdgpu_bin ||
-        mode_tensix || mode_nvidia || mode_metal || mode_intel || mode_rv_elf || mode_cpu || mode_rv64) {
+        mode_tensix || mode_nvidia || mode_metal || mode_intel || mode_rv_elf || mode_cpu || mode_rv64 ||
+        mode_tdf || mode_tdf_fission) {
         parser_t P;
         parser_init(&P, token_buf, L.num_tokens, lex_src,
                     node_buf, BC_MAX_NODES);
@@ -914,7 +916,8 @@ int main(int argc, char *argv[])
         sema_ctx_t *sema_ctx = NULL;
         if ((mode_sema || mode_ir || mode_amdgpu || mode_amdgpu_bin ||
              mode_tensix || mode_nvidia || mode_metal || mode_intel ||
-             mode_cpu || mode_rv64 || mode_rv_elf) &&
+             mode_cpu || mode_rv64 || mode_rv_elf ||
+             mode_tdf || mode_tdf_fission) &&
             P.num_errors == 0)
         {
             sema_ctx = (sema_ctx_t *)malloc(sizeof(sema_ctx_t));
@@ -936,7 +939,8 @@ int main(int argc, char *argv[])
         }
 
         if ((mode_ir || mode_amdgpu || mode_amdgpu_bin || mode_tensix ||
-             mode_nvidia || mode_metal || mode_intel || mode_rv_elf || mode_cpu || mode_rv64) &&
+             mode_nvidia || mode_metal || mode_intel || mode_rv_elf || mode_cpu || mode_rv64 ||
+             mode_tdf || mode_tdf_fission) &&
             P.num_errors == 0) {
             bc_error_t lower_errs[BC_MAX_ERRORS];
             int num_lower_errs = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -655,11 +655,20 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    if (!mode_pp && !mode_lex && !mode_parse && !mode_sema && !mode_ir &&
-        !mode_amdgpu && !mode_amdgpu_bin && !mode_tensix && !mode_nvidia &&
-        !mode_metal && !mode_intel && !mode_rv_elf && !mode_cpu && !mode_rv64 &&
-        !mode_tdf && !mode_tdf_fission)
+    /* One cascade for the C99 pipeline, each level meaning "this stage, or
+     * anything downstream of it". Four independent lists is how --cpu and then
+     * --tdf reached some gates and not others. Triton keeps its own list below;
+     * it gates a different frontend and does not accept --rv-elf. */
+    int want_bir  = mode_ir || mode_tdf || mode_tdf_fission ||
+                    mode_amdgpu || mode_amdgpu_bin || mode_tensix ||
+                    mode_nvidia || mode_metal || mode_intel ||
+                    mode_rv_elf || mode_cpu || mode_rv64;
+    int want_sema = mode_sema || want_bir;
+
+    if (!mode_pp && !mode_lex && !mode_parse && !want_sema)
         mode_parse = 1;
+
+    int want_ast = mode_parse || want_sema;
 
     /* ---- HIP NOTES (1 of 2) -------------------------------------------
      * HIP is a frontend-only mode, not a separate parser. The HIP source
@@ -896,9 +905,7 @@ int main(int argc, char *argv[])
         printf("\n%u tokens, %d error(s)\n", L.num_tokens, L.num_errors);
     }
 
-    if (mode_parse || mode_sema || mode_ir || mode_amdgpu || mode_amdgpu_bin ||
-        mode_tensix || mode_nvidia || mode_metal || mode_intel || mode_rv_elf || mode_cpu || mode_rv64 ||
-        mode_tdf || mode_tdf_fission) {
+    if (want_ast) {
         parser_t P;
         parser_init(&P, token_buf, L.num_tokens, lex_src,
                     node_buf, BC_MAX_NODES);
@@ -914,11 +921,7 @@ int main(int argc, char *argv[])
 
         /* Semantic analysis */
         sema_ctx_t *sema_ctx = NULL;
-        if ((mode_sema || mode_ir || mode_amdgpu || mode_amdgpu_bin ||
-             mode_tensix || mode_nvidia || mode_metal || mode_intel ||
-             mode_cpu || mode_rv64 || mode_rv_elf ||
-             mode_tdf || mode_tdf_fission) &&
-            P.num_errors == 0)
+        if (want_sema && P.num_errors == 0)
         {
             sema_ctx = (sema_ctx_t *)malloc(sizeof(sema_ctx_t));
             if (!sema_ctx) {
@@ -938,10 +941,7 @@ int main(int argc, char *argv[])
             }
         }
 
-        if ((mode_ir || mode_amdgpu || mode_amdgpu_bin || mode_tensix ||
-             mode_nvidia || mode_metal || mode_intel || mode_rv_elf || mode_cpu || mode_rv64 ||
-             mode_tdf || mode_tdf_fission) &&
-            P.num_errors == 0) {
+        if (want_bir && P.num_errors == 0) {
             bc_error_t lower_errs[BC_MAX_ERRORS];
             int num_lower_errs = 0;
             bir_module = (bir_module_t *)malloc(sizeof(bir_module_t));

--- a/src/tdf/tdf.c
+++ b/src/tdf/tdf.c
@@ -2,6 +2,54 @@
 #include <stdio.h>
 #include <string.h>
 
+/* ---- Chip geometry ---- */
+
+/*
+ * L1 sizes from tt-metal dev_mem_map.h, MEM_L1_SIZE and MEM_MAX_KERNEL_SIZE.
+ * Wormhole's NCRISC executes from a 16 KiB IRAM and is the binding core, so its
+ * text ceiling is that rather than MEM_MAX_KERNEL_SIZE. Blackhole has no IRAM
+ * and gives every core the full budget.
+ */
+static const struct {
+    const char *name;
+    uint32_t    l1end;
+    uint32_t    txtmax;
+} k_chips[TD_CHIP_COUNT] = {
+    { "wormhole",  1464u * 1024u,   16u * 1024u },
+    { "blackhole", 1536u * 1024u, 1497u * 1024u },
+};
+
+static td_chip_t g_chip = TD_CHIP_BH;
+
+static td_chip_t chipok(td_chip_t c)
+{
+    return c < TD_CHIP_COUNT ? c : TD_CHIP_BH;
+}
+
+uint32_t td_l1end(td_chip_t c)  { return k_chips[chipok(c)].l1end; }
+uint32_t td_txtmax(td_chip_t c) { return k_chips[chipok(c)].txtmax; }
+const char *td_cname(td_chip_t c) { return k_chips[chipok(c)].name; }
+
+uint32_t td_shbase(td_chip_t c)
+{
+    return td_l1end(c) - TD_L1_SHARED_SIZE;
+}
+
+int td_pchip(const char *s, td_chip_t *out)
+{
+    if (!s || !out) return BC_ERR_TDF;
+    for (uint32_t i = 0; i < TD_CHIP_COUNT; i++) {
+        if (strcmp(s, k_chips[i].name) == 0) {
+            *out = (td_chip_t)i;
+            return BC_OK;
+        }
+    }
+    return BC_ERR_TDF;
+}
+
+void td_setchip(td_chip_t c) { g_chip = chipok(c); }
+td_chip_t td_chip(void)      { return g_chip; }
+
 /*
  * Tile DataFlow builder, lookups, and dumper.
  *

--- a/src/tdf/tdf.h
+++ b/src/tdf/tdf.h
@@ -53,8 +53,25 @@
  * channels nine and onward (WormholeB0/.../SyncUnit.md).
  */
 #define TD_L1_BASE        0x00000000u
-#define TD_L1_END         0x0016E000u    /* one past last usable byte */
 #define TD_L1_CODE_RSV    0x00008000u    /* 32 KiB for code + stack  */
+
+/* Which part we are compiling for. Everything below that does not depend on
+ * the chip stays a #define; the two that do are accessors. */
+typedef enum {
+    TD_CHIP_WH,     /* Wormhole B0 */
+    TD_CHIP_BH,     /* Blackhole   */
+    TD_CHIP_COUNT
+} td_chip_t;
+
+uint32_t  td_l1end (td_chip_t c);   /* one past last usable L1 byte */
+uint32_t  td_txtmax(td_chip_t c);   /* largest kernel text, bytes   */
+uint32_t  td_shbase(td_chip_t c);   /* base of the __shared__ slab  */
+const char *td_cname(td_chip_t c);
+int       td_pchip (const char *s, td_chip_t *out);
+
+/* Set once from the CLI before any pass runs. A compile targets one part. */
+void      td_setchip(td_chip_t c);
+td_chip_t td_chip(void);
 /*
  * Runtime args slab sits between code and CBs. The kernel reads its CUDA
  * coordinate intrinsics (threadIdx etc.) and its scalar parameters from here,
@@ -72,10 +89,9 @@
  * hard reservation rather than an open-ended region: a baby core runs one block,
  * so the whole shared footprint is known at compile time and a kernel that wants
  * more than this is refused rather than allowed to walk into the CB area. The
- * placer's ceiling is TD_L1_SHARED_BASE, which is what keeps the two apart.
+ * placer's ceiling is td_shbase(), which is what keeps the two apart.
  */
 #define TD_L1_SHARED_SIZE 0x00010000u    /* 64 KiB */
-#define TD_L1_SHARED_BASE (TD_L1_END - TD_L1_SHARED_SIZE)
 #define TD_L1_ALIGN       16u            /* C16 NoC alignment        */
 #define TD_FIFO_BYTES     8u             /* head + tail, L1 fallback */
 #define TD_HW_SEMS        8u             /* hardware semaphore count */

--- a/src/tdf/tdf.h
+++ b/src/tdf/tdf.h
@@ -36,8 +36,12 @@
  * Source citations sit next to each value because the gap between spec and
  * reverse-engineered-from-tt-metal is wide and load-bearing, and future-us needs
  * to know which number is gospel and which is a sensible guess. Wormhole L1 is
- * 1,464 KiB usable from 0x00000000 to 0x0016FFFF, organised as 16 banks of
- * 91.5 KiB (WormholeB0/TensixTile/L1.md). The 32 KiB code reservation is OUR
+ * 1,464 KiB usable from 0x00000000 to 0x0016DFFF, organised as 16 banks of
+ * 91.5 KiB (WormholeB0/TensixTile/L1.md), which tt-metal states as
+ * MEM_L1_SIZE (1464 * 1024) in wormhole/dev_mem_map.h. Blackhole has 1,536 KiB
+ * and we do not target it: this map is the smaller of the two throughout, so a
+ * Blackhole part simply leaves the top 64 KiB unused rather than being wrong.
+ * The 32 KiB code reservation is OUR
  * call, since the docs fix no maximum kernel size and only say baby cores fetch
  * instructions from L1; it is conservative, matches typical Metalium kernels, and
  * we can adjust once real RV32IM emission lets us measure. NoC reads/writes to L1
@@ -49,7 +53,7 @@
  * channels nine and onward (WormholeB0/.../SyncUnit.md).
  */
 #define TD_L1_BASE        0x00000000u
-#define TD_L1_END         0x00170000u    /* one past last usable byte */
+#define TD_L1_END         0x0016E000u    /* one past last usable byte */
 #define TD_L1_CODE_RSV    0x00008000u    /* 32 KiB for code + stack  */
 /*
  * Runtime args slab sits between code and CBs. The kernel reads its CUDA
@@ -62,6 +66,16 @@
 #define TD_L1_RTARG_BASE  TD_L1_CODE_RSV
 #define TD_L1_RTARG_SIZE  0x00000100u
 #define TD_L1_CB_BASE     (TD_L1_RTARG_BASE + TD_L1_RTARG_SIZE)
+/*
+ * __shared__ is carved off the top of L1 growing down, so circular buffers keep
+ * packing upward from TD_L1_CB_BASE without their base moving. The size is a
+ * hard reservation rather than an open-ended region: a baby core runs one block,
+ * so the whole shared footprint is known at compile time and a kernel that wants
+ * more than this is refused rather than allowed to walk into the CB area. The
+ * placer's ceiling is TD_L1_SHARED_BASE, which is what keeps the two apart.
+ */
+#define TD_L1_SHARED_SIZE 0x00010000u    /* 64 KiB */
+#define TD_L1_SHARED_BASE (TD_L1_END - TD_L1_SHARED_SIZE)
 #define TD_L1_ALIGN       16u            /* C16 NoC alignment        */
 #define TD_FIFO_BYTES     8u             /* head + tail, L1 fallback */
 #define TD_HW_SEMS        8u             /* hardware semaphore count */

--- a/src/tdf/tdf_place.c
+++ b/src/tdf/tdf_place.c
@@ -59,13 +59,14 @@ int td_place_l1(td_mod_t *M)
         uint32_t data_b = tile_b * (uint32_t)c->depth;
         uint32_t total  = round_up(data_b + TD_FIFO_BYTES, TD_L1_ALIGN);
 
-        /* Ceiling is the shared slab, not the end of L1: __shared__ is carved
+        /* Ceiling is the shared slab, not the end of L1. __shared__ is carved
          * off the top, and packing a channel past this would overlap it. */
-        if (cur > TD_L1_SHARED_BASE || total > TD_L1_SHARED_BASE - cur) {
+        uint32_t top = td_shbase(td_chip());
+        if (cur > top || total > top - cur) {
             fprintf(stderr,
                     "tdf: L1 budget exceeded at channel %u "
-                    "(want %u bytes at 0x%x, CB area ends at 0x%x)\n",
-                    c->id, total, cur, TD_L1_SHARED_BASE);
+                    "(want %u bytes at 0x%x, CB area ends at 0x%x on %s)\n",
+                    c->id, total, cur, top, td_cname(td_chip()));
             return BC_ERR_TDF;
         }
         cur += total;

--- a/src/tdf/tdf_place.c
+++ b/src/tdf/tdf_place.c
@@ -59,11 +59,13 @@ int td_place_l1(td_mod_t *M)
         uint32_t data_b = tile_b * (uint32_t)c->depth;
         uint32_t total  = round_up(data_b + TD_FIFO_BYTES, TD_L1_ALIGN);
 
-        if (cur > TD_L1_END || total > TD_L1_END - cur) {
+        /* Ceiling is the shared slab, not the end of L1: __shared__ is carved
+         * off the top, and packing a channel past this would overlap it. */
+        if (cur > TD_L1_SHARED_BASE || total > TD_L1_SHARED_BASE - cur) {
             fprintf(stderr,
                     "tdf: L1 budget exceeded at channel %u "
-                    "(want %u bytes at 0x%x, L1 ends at 0x%x)\n",
-                    c->id, total, cur, TD_L1_END);
+                    "(want %u bytes at 0x%x, CB area ends at 0x%x)\n",
+                    c->id, total, cur, TD_L1_SHARED_BASE);
             return BC_ERR_TDF;
         }
         cur += total;

--- a/src/tensix/rv_buf.c
+++ b/src/tensix/rv_buf.c
@@ -30,7 +30,7 @@ int rv_buf_patch(rv_buf_t *b, uint32_t idx, uint32_t word)
 }
 
 uint32_t rv_buf_n_words(const rv_buf_t *b)      { return b->n; }
-uint32_t rv_buf_pos_bytes(const rv_buf_t *b)    { return b->n * 4u; }
+uint32_t rv_buf_nbytes(const rv_buf_t *b)    { return b->n * 4u; }
 const uint32_t *rv_buf_data(const rv_buf_t *b)  { return b->words; }
 
 int32_t rv_buf_offset(const rv_buf_t *b, uint32_t from, uint32_t to)

--- a/src/tensix/rv_buf.h
+++ b/src/tensix/rv_buf.h
@@ -33,7 +33,7 @@ int            rv_buf_emit(rv_buf_t *b, uint32_t word);
 int            rv_buf_patch(rv_buf_t *b, uint32_t idx, uint32_t word);
 
 uint32_t       rv_buf_n_words(const rv_buf_t *b);
-uint32_t       rv_buf_pos_bytes(const rv_buf_t *b);   /* n * 4 */
+uint32_t       rv_buf_nbytes(const rv_buf_t *b);   /* n * 4 */
 const uint32_t *rv_buf_data(const rv_buf_t *b);
 
 /*

--- a/src/tensix/rv_elf.c
+++ b/src/tensix/rv_elf.c
@@ -3,13 +3,9 @@
 #include <string.h>
 
 /*
- * ELF32 little-endian header writer. The constants are inlined as literals
- * rather than pulled from elf.h because there's no portable elf.h on
- * Windows/MinGW, and inlining keeps the build dependency-free, which is the
- * whole point of this compiler. All multibyte fields are written little-endian,
- * matching both the ELFDATA2LSB declaration and the host x86-64 byte order the
- * compiler runs on. Porting to a big-endian host would need explicit
- * byte-swizzling, which is a problem we can have when we have it.
+ * ELF32 little-endian writer. Constants are inlined rather than pulled from
+ * elf.h because MinGW has no portable one. All fields are written
+ * little-endian; a big-endian host would need byte-swizzling.
  */
 
 /* ---- Constants ---- */
@@ -29,53 +25,81 @@
 
 #define PT_LOAD        1u
 #define PF_X           1u
-#define PF_W           2u
 #define PF_R           4u
 
 #define SHT_NULL       0u
 #define SHT_PROGBITS   1u
+#define SHT_SYMTAB     2u
 #define SHT_STRTAB     3u
+#define SHT_RELA       4u
 
 #define SHF_ALLOC      2u
 #define SHF_EXECINSTR  4u
 
+#define STB_GLOBAL     1u
+#define STT_FUNC       2u
+
 #define EHDR_SIZE      52u
 #define PHDR_SIZE      32u
 #define SHDR_SIZE      40u
+#define SYM_SIZE       16u
+#define RELA_SIZE      12u
+
+/* Section header indices, in the order we emit them. */
+#define SEC_NULL       0u
+#define SEC_TEXT       1u
+#define SEC_RELA       2u
+#define SEC_SYMTAB     3u
+#define SEC_STRTAB     4u
+#define SEC_SEGS       5u
+#define SEC_SHSTR      6u
+#define SEC_COUNT      7u
+
+/* ---- String tables ---- */
+
+static const char k_shstr[] =
+    "\0.text\0.rela.text\0.symtab\0.strtab\0.segments\0.shstrtab\0";
+#define SHSTR_SIZE      54u
+#define SHSTR_TEXT      1u
+#define SHSTR_RELA      7u
+#define SHSTR_SYMTAB    18u
+#define SHSTR_STRTAB    26u
+#define SHSTR_SEGS      34u
+#define SHSTR_SHSTR     44u
+
+static const char k_str[] = "\0_start\0";
+#define STR_SIZE        8u
+#define STR_START       1u
 
 /* ---- Little-endian writers ---- */
 
-static void w8 (uint8_t  **p, uint8_t  v) { **p = v;       (*p)++; }
-static void w16(uint8_t  **p, uint16_t v)
+static void w8(uint8_t **p, uint8_t v) { **p = v; (*p)++; }
+
+static void w16(uint8_t **p, uint16_t v)
 {
     (*p)[0] = (uint8_t)(v & 0xFFu);
     (*p)[1] = (uint8_t)((v >> 8) & 0xFFu);
     *p += 2;
 }
-static void w32(uint8_t  **p, uint32_t v)
+
+static void w32(uint8_t **p, uint32_t v)
 {
-    (*p)[0] = (uint8_t)(v        & 0xFFu);
-    (*p)[1] = (uint8_t)((v >> 8) & 0xFFu);
+    (*p)[0] = (uint8_t)(v         & 0xFFu);
+    (*p)[1] = (uint8_t)((v >> 8)  & 0xFFu);
     (*p)[2] = (uint8_t)((v >> 16) & 0xFFu);
     (*p)[3] = (uint8_t)((v >> 24) & 0xFFu);
     *p += 4;
 }
 
+static uint32_t alignup(uint32_t x, uint32_t a)
+{
+    return (x + (a - 1u)) & ~(a - 1u);
+}
+
 /* ---- Header builders ---- */
 
-/* Section names live in a tiny 17-byte string table: offset 0 is the empty
- * string every strtab starts with, offset 1 is ".text" (5 chars plus NUL) and
- * offset 7 is ".shstrtab" (9 chars plus NUL). */
-static const char k_shstrtab[] = "\0.text\0.shstrtab\0";
-#define SHSTRTAB_SIZE   17u
-#define SHSTR_OFF_TEXT  1u
-#define SHSTR_OFF_SHSTR 7u
-
-static void write_ehdr(uint8_t **p, uint32_t e_phoff, uint32_t e_shoff,
-                       uint32_t e_phnum, uint32_t e_shnum,
-                       uint32_t e_shstrndx)
+static void w_ehdr(uint8_t **p, uint32_t shoff)
 {
-    /* e_ident: 16 bytes */
     w8(p, ELF_MAGIC0);
     w8(p, ELF_MAGIC1);
     w8(p, ELF_MAGIC2);
@@ -84,72 +108,90 @@ static void write_ehdr(uint8_t **p, uint32_t e_phoff, uint32_t e_shoff,
     w8(p, ELFDATA2LSB);
     w8(p, EV_CURRENT);
     w8(p, ELFOSABI_NONE);
-    for (int i = 0; i < 8; i++) w8(p, 0);   /* padding */
+    for (int i = 0; i < 8; i++) w8(p, 0);
 
-    w16(p, (uint16_t)ET_EXEC);                /* e_type */
-    w16(p, (uint16_t)EM_RISCV);               /* e_machine */
-    w32(p, EV_CURRENT);                       /* e_version */
-    w32(p, RV_ELF_ENTRY);                     /* e_entry */
-    w32(p, e_phoff);                          /* e_phoff */
-    w32(p, e_shoff);                          /* e_shoff */
-    w32(p, 0);                                /* e_flags, soft-float ABI */
-    w16(p, (uint16_t)EHDR_SIZE);              /* e_ehsize */
-    w16(p, (uint16_t)PHDR_SIZE);              /* e_phentsize */
-    w16(p, (uint16_t)e_phnum);                /* e_phnum */
-    w16(p, (uint16_t)SHDR_SIZE);              /* e_shentsize */
-    w16(p, (uint16_t)e_shnum);                /* e_shnum */
-    w16(p, (uint16_t)e_shstrndx);             /* e_shstrndx */
+    w16(p, (uint16_t)ET_EXEC);
+    w16(p, (uint16_t)EM_RISCV);
+    w32(p, EV_CURRENT);
+    /* Must equal the first PT_LOAD's p_vaddr or ReadImage rejects the image. */
+    w32(p, RV_ELF_ENTRY);
+    w32(p, EHDR_SIZE);
+    w32(p, shoff);
+    w32(p, 0);                        /* e_flags; the loader never reads it */
+    w16(p, (uint16_t)EHDR_SIZE);
+    w16(p, (uint16_t)PHDR_SIZE);
+    w16(p, 1u);
+    w16(p, (uint16_t)SHDR_SIZE);
+    w16(p, (uint16_t)SEC_COUNT);
+    w16(p, (uint16_t)SEC_SHSTR);
 }
 
-static void write_phdr(uint8_t **p, uint32_t p_offset, uint32_t p_vaddr,
-                       uint32_t p_filesz, uint32_t p_memsz,
-                       uint32_t p_flags, uint32_t p_align)
+static void w_phdr(uint8_t **p, uint32_t off, uint32_t sz)
 {
-    w32(p, PT_LOAD);    /* p_type */
-    w32(p, p_offset);   /* p_offset */
-    w32(p, p_vaddr);    /* p_vaddr */
-    w32(p, p_vaddr);    /* p_paddr, same as vaddr on Tensix (no MMU) */
-    w32(p, p_filesz);
-    w32(p, p_memsz);
-    w32(p, p_flags);
-    w32(p, p_align);
+    w32(p, PT_LOAD);
+    w32(p, off);
+    w32(p, RV_ELF_LOAD_ADDR);
+    w32(p, RV_ELF_LOAD_ADDR);         /* LMA equals VMA; no MMU */
+    w32(p, sz);
+    w32(p, sz);
+    w32(p, PF_R | PF_X);
+    w32(p, RV_ELF_SEG_ALIGN);
 }
 
-static void write_shdr(uint8_t **p, uint32_t name, uint32_t type,
-                       uint32_t flags, uint32_t addr, uint32_t offset,
-                       uint32_t size, uint32_t link, uint32_t info,
-                       uint32_t addralign, uint32_t entsize)
+static void w_shdr(uint8_t **p, uint32_t name, uint32_t type, uint32_t flags,
+                   uint32_t addr, uint32_t off, uint32_t sz, uint32_t link,
+                   uint32_t info, uint32_t align, uint32_t entsz)
 {
-    w32(p, name);        /* sh_name (index into .shstrtab) */
-    w32(p, type);        /* sh_type */
+    w32(p, name);
+    w32(p, type);
     w32(p, flags);
     w32(p, addr);
-    w32(p, offset);
-    w32(p, size);
+    w32(p, off);
+    w32(p, sz);
     w32(p, link);
     w32(p, info);
-    w32(p, addralign);
-    w32(p, entsize);
+    w32(p, align);
+    w32(p, entsz);
+}
+
+static void w_sym(uint8_t **p, uint32_t name, uint32_t val, uint32_t sz,
+                  uint8_t info, uint16_t shndx)
+{
+    w32(p, name);
+    w32(p, val);
+    w32(p, sz);
+    w8(p, info);
+    w8(p, 0);                         /* st_other */
+    w16(p, shndx);
 }
 
 /* ---- Layout planner ---- */
 
 typedef struct {
-    uint32_t code_off;
-    uint32_t code_sz;
+    uint32_t text_off;
+    uint32_t text_sz;
+    uint32_t segs_off;
+    uint32_t rela_off;
+    uint32_t sym_off;
+    uint32_t str_off;
     uint32_t shstr_off;
     uint32_t shdr_off;
-    uint32_t total_sz;
-} rv_elf_lay_t;
+    uint32_t total;
+} lay_t;
 
-static void plan_layout(uint32_t code_bytes, rv_elf_lay_t *l)
+/* The loader demands p_offset, p_vaddr and p_paddr share 4-byte alignment, and
+ * that every alloc, rela and symtab section is 4-byte aligned on disk. */
+static void plan(uint32_t code_bytes, lay_t *l)
 {
-    l->code_off  = EHDR_SIZE + PHDR_SIZE;
-    l->code_sz   = code_bytes;
-    l->shstr_off = l->code_off + l->code_sz;
-    l->shdr_off  = l->shstr_off + SHSTRTAB_SIZE;
-    /* Three section headers: NULL, .text, .shstrtab. */
-    l->total_sz  = l->shdr_off + 3u * SHDR_SIZE;
+    l->text_off  = alignup(EHDR_SIZE + PHDR_SIZE, RV_ELF_SEG_ALIGN);
+    l->text_sz   = code_bytes;
+    l->segs_off  = alignup(l->text_off + l->text_sz, 4u);
+    l->rela_off  = l->segs_off + 12u;
+    l->sym_off   = l->rela_off;       /* .rela.text is empty, so it occupies nothing */
+    l->str_off   = l->sym_off + 2u * SYM_SIZE;
+    l->shstr_off = l->str_off + STR_SIZE;
+    l->shdr_off  = alignup(l->shstr_off + SHSTR_SIZE, 4u);
+    l->total     = l->shdr_off + SEC_COUNT * SHDR_SIZE;
 }
 
 /* ---- Public entry point ---- */
@@ -161,73 +203,82 @@ int rv_elf_write(const rv_buf_t *code, const char *path)
         return BC_ERR_IO;
     }
 
-    uint32_t code_bytes = rv_buf_pos_bytes(code);
+    uint32_t code_bytes = rv_buf_nbytes(code);
     if (code_bytes == 0u) {
         fprintf(stderr, "rv_elf: refusing to write an empty kernel\n");
         return BC_ERR_IO;
     }
-
-    rv_elf_lay_t lay;
-    plan_layout(code_bytes, &lay);
-
-    /* Fixed maximum size of 16 KiB code plus 256 bytes of header and section
-     * metadata. The write below treats the buffer as a single blob, so we cap it
-     * here and refuse anything bigger. */
-    static uint8_t out[RV_BUF_MAX_WORDS * 4u + 256u];
-    if (lay.total_sz > sizeof(out)) {
-        fprintf(stderr,
-                "rv_elf: kernel image %u bytes exceeds buffer %lu\n",
-                lay.total_sz, (unsigned long)sizeof(out));
+    if (code_bytes > RV_ELF_TEXT_LIMIT) {
+        fprintf(stderr, "rv_elf: text %u bytes exceeds baby-core limit %u\n",
+                code_bytes, RV_ELF_TEXT_LIMIT);
         return BC_ERR_IO;
     }
 
-    memset(out, 0, lay.total_sz);
+    lay_t lay;
+    plan(code_bytes, &lay);
+
+    static uint8_t out[RV_BUF_MAX_WORDS * 4u + 512u];
+    if (lay.total > sizeof(out)) {
+        fprintf(stderr, "rv_elf: image %u bytes exceeds buffer %lu\n",
+                lay.total, (unsigned long)sizeof(out));
+        return BC_ERR_IO;
+    }
+
+    memset(out, 0, lay.total);
     uint8_t *p = out;
 
-    /* ELF header */
-    write_ehdr(&p,
-               EHDR_SIZE,                     /* e_phoff: right after ehdr */
-               lay.shdr_off,                  /* e_shoff */
-               1u,                            /* e_phnum: one PT_LOAD */
-               3u,                            /* e_shnum: NULL/.text/.shstrtab */
-               2u);                           /* e_shstrndx: .shstrtab at idx 2 */
+    w_ehdr(&p, lay.shdr_off);
+    w_phdr(&p, lay.text_off, code_bytes);
 
-    /* Program header */
-    write_phdr(&p,
-               lay.code_off,
-               RV_ELF_LOAD_ADDR,
-               code_bytes,
-               code_bytes,
-               PF_R | PF_X,
-               4u);
+    memcpy(out + lay.text_off, rv_buf_data(code), code_bytes);
 
-    /* Code bytes */
-    memcpy(out + lay.code_off, rv_buf_data(code), code_bytes);
+    /* .segments: one (vma, trim_bound, size_limit) triple per loadable segment.
+     * trim_bound equal to the vma makes the loader's head-trim a no-op. */
+    p = out + lay.segs_off;
+    w32(&p, RV_ELF_LOAD_ADDR);
+    w32(&p, RV_ELF_LOAD_ADDR);
+    w32(&p, RV_ELF_TEXT_LIMIT);
 
-    /* .shstrtab content */
-    memcpy(out + lay.shstr_off, k_shstrtab, SHSTRTAB_SIZE);
+    /* XIPify resolves relocation symbols through .symtab, so it must exist even
+     * though we emit no entries. Index 0 is the reserved null symbol. */
+    p = out + lay.sym_off;
+    w_sym(&p, 0, 0, 0, 0, 0);
+    w_sym(&p, STR_START, RV_ELF_LOAD_ADDR, code_bytes,
+          (uint8_t)((STB_GLOBAL << 4) | STT_FUNC), (uint16_t)SEC_TEXT);
 
-    /* Section header table */
+    memcpy(out + lay.str_off, k_str, STR_SIZE);
+    memcpy(out + lay.shstr_off, k_shstr, SHSTR_SIZE);
+
     p = out + lay.shdr_off;
-    write_shdr(&p, 0, SHT_NULL,     0, 0, 0, 0, 0, 0, 0, 0);
-    write_shdr(&p, SHSTR_OFF_TEXT,  SHT_PROGBITS,
-               SHF_ALLOC | SHF_EXECINSTR,
-               RV_ELF_LOAD_ADDR, lay.code_off, code_bytes,
-               0, 0, 4, 0);
-    write_shdr(&p, SHSTR_OFF_SHSTR, SHT_STRTAB,
-               0, 0, lay.shstr_off, SHSTRTAB_SIZE,
-               0, 0, 1, 0);
+    w_shdr(&p, 0, SHT_NULL, 0, 0, 0, 0, 0, 0, 0, 0);
+    w_shdr(&p, SHSTR_TEXT, SHT_PROGBITS, SHF_ALLOC | SHF_EXECINSTR,
+           RV_ELF_LOAD_ADDR, lay.text_off, code_bytes, 0, 0, 4u, 0);
+    /* Empty, but its presence is what stops the loader throwing "there are no
+     * relocation sections". sh_info must name an alloc section inside a
+     * segment or the loader skips it and the count stays zero. */
+    w_shdr(&p, SHSTR_RELA, SHT_RELA, 0, 0, lay.rela_off, 0,
+           SEC_SYMTAB, SEC_TEXT, 4u, RELA_SIZE);
+    /* sh_info is the index of the first non-local symbol. */
+    w_shdr(&p, SHSTR_SYMTAB, SHT_SYMTAB, 0, 0, lay.sym_off, 2u * SYM_SIZE,
+           SEC_STRTAB, 1u, 4u, SYM_SIZE);
+    w_shdr(&p, SHSTR_STRTAB, SHT_STRTAB, 0, 0, lay.str_off, STR_SIZE,
+           0, 0, 1u, 0);
+    /* Non-alloc and SHT_PROGBITS, which is how the loader identifies it. */
+    w_shdr(&p, SHSTR_SEGS, SHT_PROGBITS, 0, 0, lay.segs_off, 12u,
+           0, 0, 4u, 0);
+    w_shdr(&p, SHSTR_SHSTR, SHT_STRTAB, 0, 0, lay.shstr_off, SHSTR_SIZE,
+           0, 0, 1u, 0);
 
     FILE *fp = fopen(path, "wb");
     if (!fp) {
         fprintf(stderr, "rv_elf: cannot open %s for writing\n", path);
         return BC_ERR_IO;
     }
-    size_t wrote = fwrite(out, 1, lay.total_sz, fp);
+    size_t wrote = fwrite(out, 1, lay.total, fp);
     fclose(fp);
-    if (wrote != lay.total_sz) {
+    if (wrote != lay.total) {
         fprintf(stderr, "rv_elf: short write to %s (%lu of %u)\n",
-                path, (unsigned long)wrote, lay.total_sz);
+                path, (unsigned long)wrote, lay.total);
         return BC_ERR_IO;
     }
     return BC_OK;

--- a/src/tensix/rv_elf.c
+++ b/src/tensix/rv_elf.c
@@ -208,9 +208,10 @@ int rv_elf_write(const rv_buf_t *code, const char *path)
         fprintf(stderr, "rv_elf: refusing to write an empty kernel\n");
         return BC_ERR_IO;
     }
-    if (code_bytes > RV_ELF_TEXT_LIMIT) {
-        fprintf(stderr, "rv_elf: text %u bytes exceeds baby-core limit %u\n",
-                code_bytes, RV_ELF_TEXT_LIMIT);
+    uint32_t txtmax = td_txtmax(td_chip());
+    if (code_bytes > txtmax) {
+        fprintf(stderr, "rv_elf: text %u bytes exceeds the %s limit of %u\n",
+                code_bytes, td_cname(td_chip()), txtmax);
         return BC_ERR_IO;
     }
 
@@ -237,7 +238,7 @@ int rv_elf_write(const rv_buf_t *code, const char *path)
     p = out + lay.segs_off;
     w32(&p, RV_ELF_LOAD_ADDR);
     w32(&p, RV_ELF_LOAD_ADDR);
-    w32(&p, RV_ELF_TEXT_LIMIT);
+    w32(&p, txtmax);
 
     /* XIPify resolves relocation symbols through .symtab, so it must exist even
      * though we emit no entries. Index 0 is the reserved null symbol. */

--- a/src/tensix/rv_elf.h
+++ b/src/tensix/rv_elf.h
@@ -5,36 +5,35 @@
 #include "rv_buf.h"
 
 /*
- * RV32IM ELF emitter for the Tenstorrent Wormhole baby RISC-V cores. The file
- * it produces is an ELF32 header, a PT_LOAD program header, 4-byte-aligned code,
- * the .shstrtab contents, and a three-entry section header table. The constants
- * below come from the System V ABI ELF32 spec and sfpi-binutils common.h
- * (ELFCLASS32=1, ELFDATA2LSB=1, ET_EXEC=2, EM_RISCV=243, EV_CURRENT=1); the L1
- * base of 0x00000000 comes from the tt-isa-documentation BabyRISCV README, and
- * the tt-metal SDK loads via PT_LOAD with sections as optional metadata any
- * reasonable disassembler will read.
+ * RV32IM ELF emitter for the Tenstorrent baby RISC-V cores. The shape is
+ * dictated by tt-metal's loader in tt_metal/llrt/tt_elffile.cpp, which is
+ * stricter than the System V ABI alone: sections are mandatory, a .segments
+ * metadata section drives trimming and size checks, and a kernel must carry at
+ * least one relocation section or ReadImage throws outright.
  *
- * It's a soft-float ABI with no compressed instructions and no F/D extension, so
- * e_flags = 0; EF_RISCV_FLOAT_ABI_SOFT happens to also be 0, so this is correct
- * rather than accidentally correct. What it does NOT do today is relocations,
- * symbol tables, debug info, or BSS: the current path expects a self-contained
- * kernel with no external symbol references, which is fine for the first
- * integer-only bring-up.
+ * We emit no relocation entries because every branch and call is patched
+ * PC-relative at selection time, and XIP relocates the text segment as a unit.
+ * The empty .rela.text exists purely to satisfy the loader's count.
  */
 
-/* L1 base address where code is loaded. Spec source above. */
+/* Text VMA. Three fields must agree on it: e_entry, the first PT_LOAD's
+ * p_vaddr, and the .segments vma. TrimSegments runs during ReadImage and
+ * matches on the link-time address, whereas XIPify only rezeros it afterwards,
+ * so moving this off zero means moving all three together. */
 #define RV_ELF_LOAD_ADDR  0x00000000u
-
-/* Entry point at the start of code. The spec is silent on whether the tt-metal
- * loader honours e_entry or assumes a known address, so we set both to
- * RV_ELF_LOAD_ADDR and hope they line up. The PC register the host writes on
- * launch lives in Tensix MMIO and is undocumented in the public ISA reference. */
 #define RV_ELF_ENTRY      RV_ELF_LOAD_ADDR
+
+/* Tightest baby-core budget (Wormhole NCRISC IRAM), used as the .segments
+ * size limit. RV_BUF_MAX_WORDS*4 happens to equal this exactly, so the guard
+ * in rv_elf_write is unreachable until one of the two constants moves. */
+#define RV_ELF_TEXT_LIMIT (16u * 1024u)
+
+/* tt-metal links with -Wl,-z,max-page-size=16. */
+#define RV_ELF_SEG_ALIGN  16u
 
 /*
  * Write a code buffer to an RV32IM ELF file at the given path. Returns BC_OK on
- * success or a BC_ERR_* code on failure. The caller handles any post-write steps
- * like chmod or staging onto the deploy host.
+ * success or a BC_ERR_* code on failure.
  */
 int rv_elf_write(const rv_buf_t *code, const char *path);
 

--- a/src/tensix/rv_elf.h
+++ b/src/tensix/rv_elf.h
@@ -3,6 +3,7 @@
 
 #include "barracuda.h"
 #include "rv_buf.h"
+#include "tdf.h"     /* td_txtmax, td_chip */
 
 /*
  * RV32IM ELF emitter for the Tenstorrent baby RISC-V cores. The shape is
@@ -23,10 +24,9 @@
 #define RV_ELF_LOAD_ADDR  0x00000000u
 #define RV_ELF_ENTRY      RV_ELF_LOAD_ADDR
 
-/* Tightest baby-core budget (Wormhole NCRISC IRAM), used as the .segments
- * size limit. RV_BUF_MAX_WORDS*4 happens to equal this exactly, so the guard
- * in rv_elf_write is unreachable until one of the two constants moves. */
-#define RV_ELF_TEXT_LIMIT (16u * 1024u)
+/* The .segments size limit is the target chip's text budget, td_txtmax(). The
+ * compiler's own ceiling is RV_BUF_MAX_WORDS and is reported separately, so a
+ * kernel that outgrows the buffer says so rather than blaming the hardware. */
 
 /* tt-metal links with -Wl,-z,max-page-size=16. */
 #define RV_ELF_SEG_ALIGN  16u

--- a/src/tensix/rv_enc.c
+++ b/src/tensix/rv_enc.c
@@ -36,7 +36,7 @@ static uint32_t enc_i(int16_t imm, uint8_t rs1, uint32_t f3,
          |  (op & 0x7Fu);
 }
 
-static uint32_t enc_i_shift(uint32_t f7, uint8_t shamt, uint8_t rs1,
+static uint32_t enc_ish(uint32_t f7, uint8_t shamt, uint8_t rs1,
                             uint32_t f3, uint8_t rd, uint32_t op)
 {
     /* I-type immediate split for shifts: bits[24:20] are the 5-bit
@@ -136,9 +136,9 @@ uint32_t rv_xori (uint8_t rd, uint8_t rs1, int16_t imm) { return enc_i(imm, rs1,
 uint32_t rv_slti (uint8_t rd, uint8_t rs1, int16_t imm) { return enc_i(imm, rs1, 0x2, rd, 0x13); }
 uint32_t rv_sltiu(uint8_t rd, uint8_t rs1, int16_t imm) { return enc_i(imm, rs1, 0x3, rd, 0x13); }
 
-uint32_t rv_slli(uint8_t rd, uint8_t rs1, uint8_t shamt) { return enc_i_shift(0x00, shamt, rs1, 0x1, rd, 0x13); }
-uint32_t rv_srli(uint8_t rd, uint8_t rs1, uint8_t shamt) { return enc_i_shift(0x00, shamt, rs1, 0x5, rd, 0x13); }
-uint32_t rv_srai(uint8_t rd, uint8_t rs1, uint8_t shamt) { return enc_i_shift(0x20, shamt, rs1, 0x5, rd, 0x13); }
+uint32_t rv_slli(uint8_t rd, uint8_t rs1, uint8_t shamt) { return enc_ish(0x00, shamt, rs1, 0x1, rd, 0x13); }
+uint32_t rv_srli(uint8_t rd, uint8_t rs1, uint8_t shamt) { return enc_ish(0x00, shamt, rs1, 0x5, rd, 0x13); }
+uint32_t rv_srai(uint8_t rd, uint8_t rs1, uint8_t shamt) { return enc_ish(0x20, shamt, rs1, 0x5, rd, 0x13); }
 
 /* ---- Loads (LOAD, opcode=0x03) ---- */
 

--- a/src/tensix/rv_isel.c
+++ b/src/tensix/rv_isel.c
@@ -40,10 +40,10 @@ typedef struct {
     uint8_t  rs1;            /* condition register for BEQ/BNE      */
 } patch_t;
 
-static uint32_t block_word_idx[ISEL_MAX_BLOCKS];
-static uint8_t  block_known[ISEL_MAX_BLOCKS];
+static uint32_t blkwidx[ISEL_MAX_BLOCKS];
+static uint8_t  blkknwn[ISEL_MAX_BLOCKS];
 static patch_t  patches[ISEL_MAX_PATCHES];
-static uint32_t num_patches;
+static uint32_t npatch;
 
 /*
  * PHI destruction scratch. For each PHI (block, value) pair in the
@@ -62,10 +62,10 @@ typedef struct {
     uint16_t pred_block;   /* predecessor block this copy fires in */
     uint16_t phi_inst;     /* destination slot (PHI's inst index)   */
     uint32_t src_val;      /* value handle (CONST or VAL)           */
-} phi_copy_t;
+} phicp_t;
 
-static phi_copy_t phi_copies[ISEL_MAX_PHI_COPIES];
-static uint32_t   num_phi_copies;
+static phicp_t phicp[ISEL_MAX_PHI_COPIES];
+static uint32_t   nphicp;
 
 /*
  * Per-function position tracking for inter-function calls. When a
@@ -88,50 +88,55 @@ typedef struct {
     uint32_t jal_word_idx;   /* placeholder location in the buffer */
     uint16_t callee_func;    /* target function index in M->funcs[] */
     uint16_t _pad;
-} call_patch_t;
+} calpat_t;
 
-static uint32_t     func_word_idx[ISEL_MAX_FUNCS];
-static uint8_t      func_known[ISEL_MAX_FUNCS];
-static call_patch_t call_patches[ISEL_MAX_CALLS];
-static uint32_t     num_call_patches;
-static uint32_t     current_func_idx;     /* set per-function during emit */
+static uint32_t     fnwidx[ISEL_MAX_FUNCS];
+static uint8_t      fnknwn[ISEL_MAX_FUNCS];
+static calpat_t calpat[ISEL_MAX_CALLS];
+static uint32_t     ncalpat;
+static uint32_t     curfn;     /* set per-function during emit */
 
-static void isel_reset_cf(void)
+/* Module-global index of this function's first instruction. Slot indices are
+ * biased by it so function N>0 addresses its own frame rather than the
+ * caller's, and so offsets stay inside the 12-bit immediate. */
+static uint32_t     slotbas;
+
+static void isel_rstcf(void)
 {
-    memset(block_word_idx, 0, sizeof(block_word_idx));
-    memset(block_known,    0, sizeof(block_known));
-    num_patches    = 0;
-    num_phi_copies = 0;
+    memset(blkwidx, 0, sizeof(blkwidx));
+    memset(blkknwn,    0, sizeof(blkknwn));
+    npatch    = 0;
+    nphicp = 0;
 }
 
-static void isel_reset_module(void)
+static void isel_rstmod(void)
 {
-    memset(func_word_idx, 0, sizeof(func_word_idx));
-    memset(func_known,    0, sizeof(func_known));
-    num_call_patches = 0;
-    current_func_idx = 0;
+    memset(fnwidx, 0, sizeof(fnwidx));
+    memset(fnknwn,    0, sizeof(fnknwn));
+    ncalpat = 0;
+    curfn = 0;
 }
 
-static int record_patch(uint32_t word_idx, uint16_t target,
+static int recpat(uint32_t word_idx, uint16_t target,
                         uint8_t kind, uint8_t rs1)
 {
-    if (num_patches >= ISEL_MAX_PATCHES) {
+    if (npatch >= ISEL_MAX_PATCHES) {
         fprintf(stderr,
                 "rv_isel: branch patch table full (%u entries)\n",
                 ISEL_MAX_PATCHES);
         return BC_ERR_TDF;
     }
-    patches[num_patches].word_idx     = word_idx;
-    patches[num_patches].target_block = target;
-    patches[num_patches].kind         = kind;
-    patches[num_patches].rs1          = rs1;
-    num_patches++;
+    patches[npatch].word_idx     = word_idx;
+    patches[npatch].target_block = target;
+    patches[npatch].kind         = kind;
+    patches[npatch].rs1          = rs1;
+    npatch++;
     return BC_OK;
 }
 
 /* ---- Helpers ---- */
 
-static uint32_t round_up(uint32_t x, uint32_t a)
+static uint32_t rndup(uint32_t x, uint32_t a)
 {
     return (x + (a - 1u)) & ~(a - 1u);
 }
@@ -142,11 +147,21 @@ static int emit(rv_buf_t *out, uint32_t word)
     return BC_OK;
 }
 
-static uint32_t slot_offset(uint32_t inst_idx)
+/* Each BIR inst gets one 4-byte slot off sp, after the prologue's saved ra.
+ * Refuses past 2047 because LW/SW take a 12-bit signed immediate and would
+ * otherwise wrap to a negative offset and address below the frame. */
+static int slotoff(uint32_t inst_idx, uint32_t *off)
 {
-    /* Each BIR inst inside the function gets one 4-byte slot,
-     * indexed off sp after the prologue's saved ra. */
-    return ISEL_LOCALS_BASE + inst_idx * 4u;
+    uint32_t o = ISEL_LOCALS_BASE + (inst_idx - slotbas) * 4u;
+    if (o > 2047u) {
+        fprintf(stderr,
+                "rv_isel: stack slot for inst %u at offset %u exceeds the "
+                "12-bit immediate; function too large for the bring-up isel\n",
+                inst_idx, o);
+        return BC_ERR_TDF;
+    }
+    *off = o;
+    return BC_OK;
 }
 
 /*
@@ -164,7 +179,7 @@ static uint32_t slot_offset(uint32_t inst_idx)
  * Unprivileged ISA section 2.4.1 (U-format) plus the sign-extension
  * note in section 2.3.
  */
-static int load_imm32(uint8_t reg, int32_t v, rv_buf_t *out)
+static int ldimm32(uint8_t reg, int32_t v, rv_buf_t *out)
 {
     if (v >= -2048 && v <= 2047) {
         return emit(out, rv_addi(reg, RV_ZERO, (int16_t)v));
@@ -187,8 +202,8 @@ static int load_imm32(uint8_t reg, int32_t v, rv_buf_t *out)
 
 /* Load a BIR operand into the given temp register, leaving the
  * register holding the value. Handles constants by materialising
- * via load_imm32, and instruction values by loading their stack slot. */
-static int load_operand(const bir_module_t *M, uint32_t operand,
+ * via ldimm32, and instruction values by loading their stack slot. */
+static int ldopnd(const bir_module_t *M, uint32_t operand,
                         uint8_t reg, rv_buf_t *out)
 {
     if (BIR_VAL_IS_CONST(operand)) {
@@ -209,7 +224,7 @@ static int load_operand(const bir_module_t *M, uint32_t operand,
                         (long long)v);
                 return BC_ERR_TDF;
             }
-            return load_imm32(reg, (int32_t)v, out);
+            return ldimm32(reg, (int32_t)v, out);
         }
         if (c->kind == BIR_CONST_NULL) {
             return emit(out, rv_addi(reg, RV_ZERO, 0));
@@ -225,7 +240,7 @@ static int load_operand(const bir_module_t *M, uint32_t operand,
             float fv = (float)c->d.fval;
             uint32_t bits;
             memcpy(&bits, &fv, sizeof(bits));
-            return load_imm32(reg, (int32_t)bits, out);
+            return ldimm32(reg, (int32_t)bits, out);
         }
         fprintf(stderr,
                 "rv_isel: constant kind %u not supported for RV32IM\n",
@@ -234,12 +249,18 @@ static int load_operand(const bir_module_t *M, uint32_t operand,
     }
     /* Instruction value: load from stack slot. */
     uint32_t idx = BIR_VAL_INDEX(operand);
-    return emit(out, rv_lw(reg, RV_SP, (int16_t)slot_offset(idx)));
+    uint32_t off;
+    int rc = slotoff(idx, &off);
+    if (rc != BC_OK) return rc;
+    return emit(out, rv_lw(reg, RV_SP, (int16_t)off));
 }
 
-static int store_result(uint8_t reg, uint32_t inst_idx, rv_buf_t *out)
+static int stres(uint8_t reg, uint32_t inst_idx, rv_buf_t *out)
 {
-    return emit(out, rv_sw(reg, RV_SP, (int16_t)slot_offset(inst_idx)));
+    uint32_t off;
+    int rc = slotoff(inst_idx, &off);
+    if (rc != BC_OK) return rc;
+    return emit(out, rv_sw(reg, RV_SP, (int16_t)off));
 }
 
 /* ---- Per-opcode handlers ---- */
@@ -248,8 +269,8 @@ static int sel_binop(const bir_module_t *M, uint32_t inst_idx,
                      const bir_inst_t *I, rv_buf_t *out)
 {
     int rc;
-    if ((rc = load_operand(M, I->operands[0], RV_T0, out)) != BC_OK) return rc;
-    if ((rc = load_operand(M, I->operands[1], RV_T1, out)) != BC_OK) return rc;
+    if ((rc = ldopnd(M, I->operands[0], RV_T0, out)) != BC_OK) return rc;
+    if ((rc = ldopnd(M, I->operands[1], RV_T1, out)) != BC_OK) return rc;
     uint32_t op = 0;
     switch (I->op) {
     /* RV32I integer ALU. */
@@ -266,6 +287,9 @@ static int sel_binop(const bir_module_t *M, uint32_t inst_idx,
      * sluggish; a future optimiser pass can recognise divides by
      * constant powers of two and rewrite to ASHR. */
     case BIR_MUL:  op = rv_mul (RV_T0, RV_T0, RV_T1); break;
+    /* High half of the unsigned product; the keystone for wide-integer
+     * carry chains, and RV32M gives it to us directly. */
+    case BIR_UMULHI: op = rv_mulhu(RV_T0, RV_T0, RV_T1); break;
     case BIR_SDIV: op = rv_div (RV_T0, RV_T0, RV_T1); break;
     case BIR_UDIV: op = rv_divu(RV_T0, RV_T0, RV_T1); break;
     case BIR_SREM: op = rv_rem (RV_T0, RV_T0, RV_T1); break;
@@ -275,7 +299,7 @@ static int sel_binop(const bir_module_t *M, uint32_t inst_idx,
         return BC_ERR_TDF;
     }
     if ((rc = emit(out, op)) != BC_OK) return rc;
-    return store_result(RV_T0, inst_idx, out);
+    return stres(RV_T0, inst_idx, out);
 }
 
 /* ---- Integer comparison ----
@@ -296,8 +320,8 @@ static int sel_icmp(const bir_module_t *M, uint32_t inst_idx,
                     const bir_inst_t *I, rv_buf_t *out)
 {
     int rc;
-    if ((rc = load_operand(M, I->operands[0], RV_T0, out)) != BC_OK) return rc;
-    if ((rc = load_operand(M, I->operands[1], RV_T1, out)) != BC_OK) return rc;
+    if ((rc = ldopnd(M, I->operands[0], RV_T0, out)) != BC_OK) return rc;
+    if ((rc = ldopnd(M, I->operands[1], RV_T1, out)) != BC_OK) return rc;
 
     switch (I->subop) {
     case BIR_ICMP_EQ:
@@ -342,7 +366,7 @@ static int sel_icmp(const bir_module_t *M, uint32_t inst_idx,
         return BC_ERR_TDF;
     }
     if (rc != BC_OK) return rc;
-    return store_result(RV_T0, inst_idx, out);
+    return stres(RV_T0, inst_idx, out);
 }
 
 /* ---- Identity casts ----
@@ -356,9 +380,9 @@ static int sel_icmp(const bir_module_t *M, uint32_t inst_idx,
 static int sel_cast_id(const bir_module_t *M, uint32_t inst_idx,
                        const bir_inst_t *I, rv_buf_t *out)
 {
-    int rc = load_operand(M, I->operands[0], RV_T0, out);
+    int rc = ldopnd(M, I->operands[0], RV_T0, out);
     if (rc != BC_OK) return rc;
-    return store_result(RV_T0, inst_idx, out);
+    return stres(RV_T0, inst_idx, out);
 }
 
 /* ---- Width conversions ----
@@ -374,7 +398,7 @@ static int sel_cast_id(const bir_module_t *M, uint32_t inst_idx,
  * bits before, which is the assumption we have to make because the
  * slot store/load pipeline keeps 32-bit values without tracking
  * provenance. */
-static uint32_t value_int_width(const bir_module_t *M, uint32_t val)
+static uint32_t valwid(const bir_module_t *M, uint32_t val)
 {
     if (BIR_VAL_IS_CONST(val)) return 32u;
     uint32_t idx = BIR_VAL_INDEX(val);
@@ -386,7 +410,7 @@ static uint32_t value_int_width(const bir_module_t *M, uint32_t val)
     return 32u;
 }
 
-static uint32_t inst_int_width(const bir_module_t *M, const bir_inst_t *I)
+static uint32_t instwid(const bir_module_t *M, const bir_inst_t *I)
 {
     if (I->type >= M->num_types) return 32u;
     const bir_type_t *t = &M->types[I->type];
@@ -398,41 +422,41 @@ static int sel_zext(const bir_module_t *M, uint32_t inst_idx,
                     const bir_inst_t *I, rv_buf_t *out)
 {
     int rc;
-    if ((rc = load_operand(M, I->operands[0], RV_T0, out)) != BC_OK) return rc;
-    uint32_t src_w = value_int_width(M, I->operands[0]);
-    if (src_w >= 32u) return store_result(RV_T0, inst_idx, out);
+    if ((rc = ldopnd(M, I->operands[0], RV_T0, out)) != BC_OK) return rc;
+    uint32_t src_w = valwid(M, I->operands[0]);
+    if (src_w >= 32u) return stres(RV_T0, inst_idx, out);
     /* SLLI (32-src_w) then SRLI clears high bits without needing
      * a mask wider than ANDI's 12-bit immediate can express. */
     uint32_t sh = 32u - src_w;
     if ((rc = emit(out, rv_slli(RV_T0, RV_T0, (uint8_t)sh))) != BC_OK) return rc;
     if ((rc = emit(out, rv_srli(RV_T0, RV_T0, (uint8_t)sh))) != BC_OK) return rc;
-    return store_result(RV_T0, inst_idx, out);
+    return stres(RV_T0, inst_idx, out);
 }
 
 static int sel_sext(const bir_module_t *M, uint32_t inst_idx,
                     const bir_inst_t *I, rv_buf_t *out)
 {
     int rc;
-    if ((rc = load_operand(M, I->operands[0], RV_T0, out)) != BC_OK) return rc;
-    uint32_t src_w = value_int_width(M, I->operands[0]);
-    if (src_w >= 32u) return store_result(RV_T0, inst_idx, out);
+    if ((rc = ldopnd(M, I->operands[0], RV_T0, out)) != BC_OK) return rc;
+    uint32_t src_w = valwid(M, I->operands[0]);
+    if (src_w >= 32u) return stres(RV_T0, inst_idx, out);
     uint32_t sh = 32u - src_w;
     if ((rc = emit(out, rv_slli(RV_T0, RV_T0, (uint8_t)sh))) != BC_OK) return rc;
     if ((rc = emit(out, rv_srai(RV_T0, RV_T0, (uint8_t)sh))) != BC_OK) return rc;
-    return store_result(RV_T0, inst_idx, out);
+    return stres(RV_T0, inst_idx, out);
 }
 
 static int sel_trunc(const bir_module_t *M, uint32_t inst_idx,
                      const bir_inst_t *I, rv_buf_t *out)
 {
     int rc;
-    if ((rc = load_operand(M, I->operands[0], RV_T0, out)) != BC_OK) return rc;
-    uint32_t dst_w = inst_int_width(M, I);
-    if (dst_w >= 32u) return store_result(RV_T0, inst_idx, out);
+    if ((rc = ldopnd(M, I->operands[0], RV_T0, out)) != BC_OK) return rc;
+    uint32_t dst_w = instwid(M, I);
+    if (dst_w >= 32u) return stres(RV_T0, inst_idx, out);
     uint32_t sh = 32u - dst_w;
     if ((rc = emit(out, rv_slli(RV_T0, RV_T0, (uint8_t)sh))) != BC_OK) return rc;
     if ((rc = emit(out, rv_srli(RV_T0, RV_T0, (uint8_t)sh))) != BC_OK) return rc;
-    return store_result(RV_T0, inst_idx, out);
+    return stres(RV_T0, inst_idx, out);
 }
 
 /* ---- Branches ----
@@ -447,14 +471,14 @@ static int sel_trunc(const bir_module_t *M, uint32_t inst_idx,
  * BEQ/BNE encode a 2-byte-aligned offset; JAL encodes the same.
  * The rv_enc layer takes a byte offset and packs the scrambled
  * immediate per the spec. */
-static int emit_br_cond(uint16_t target_block, uint8_t rs1,
+static int ebrcond(uint16_t target_block, uint8_t rs1,
                         int branch_kind, rv_buf_t *out)
 {
     /* branch_kind: 0 = BEQ (branch if rs1 == zero, i.e. false),
      *              1 = BNE (branch if rs1 != zero, i.e. true) */
-    if (target_block < ISEL_MAX_BLOCKS && block_known[target_block]) {
+    if (target_block < ISEL_MAX_BLOCKS && blkknwn[target_block]) {
         uint32_t here = rv_buf_n_words(out);
-        int32_t off = rv_buf_offset(out, here, block_word_idx[target_block]);
+        int32_t off = rv_buf_offset(out, here, blkwidx[target_block]);
         if (off < -4096 || off > 4094) {
             fprintf(stderr,
                     "rv_isel: branch offset %d out of B-type range\n", off);
@@ -468,15 +492,15 @@ static int emit_br_cond(uint16_t target_block, uint8_t rs1,
     /* Forward reference: emit a placeholder and record the patch. */
     int slot = rv_buf_emit(out, 0u);
     if (slot < 0) return BC_ERR_OVERFLOW;
-    return record_patch((uint32_t)slot, target_block,
+    return recpat((uint32_t)slot, target_block,
                         (uint8_t)branch_kind, rs1);
 }
 
-static int emit_jal_to_block(uint16_t target_block, rv_buf_t *out)
+static int ejalbk(uint16_t target_block, rv_buf_t *out)
 {
-    if (target_block < ISEL_MAX_BLOCKS && block_known[target_block]) {
+    if (target_block < ISEL_MAX_BLOCKS && blkknwn[target_block]) {
         uint32_t here = rv_buf_n_words(out);
-        int32_t off = rv_buf_offset(out, here, block_word_idx[target_block]);
+        int32_t off = rv_buf_offset(out, here, blkwidx[target_block]);
         if (off < -1048576 || off > 1048574) {
             fprintf(stderr,
                     "rv_isel: JAL offset %d out of J-type range\n", off);
@@ -486,16 +510,16 @@ static int emit_jal_to_block(uint16_t target_block, rv_buf_t *out)
     }
     int slot = rv_buf_emit(out, 0u);
     if (slot < 0) return BC_ERR_OVERFLOW;
-    return record_patch((uint32_t)slot, target_block, 2u, 0u);
+    return recpat((uint32_t)slot, target_block, 2u, 0u);
 }
 
 /*
- * Walk every PHI in the function and queue one phi_copy_t entry
+ * Walk every PHI in the function and queue one phicp_t entry
  * per incoming (block, value) pair. The PHI operand layout is
  * (block, value, block, value, ...) either inline or overflowed
  * into M->extra_operands; we handle both.
  */
-static int phi_collect(const bir_module_t *M, const bir_func_t *F)
+static int phicoll(const bir_module_t *M, const bir_func_t *F)
 {
     for (uint32_t bi = 0; bi < F->num_blocks; bi++) {
         uint32_t bk = F->first_block + bi;
@@ -528,16 +552,16 @@ static int phi_collect(const bir_module_t *M, const bir_func_t *F)
                 return BC_ERR_TDF;
             }
             for (uint32_t p = 0; p + 1 < pair_count; p += 2) {
-                if (num_phi_copies >= ISEL_MAX_PHI_COPIES) {
+                if (nphicp >= ISEL_MAX_PHI_COPIES) {
                     fprintf(stderr,
                             "rv_isel: PHI copy table full (%u entries)\n",
                             ISEL_MAX_PHI_COPIES);
                     return BC_ERR_TDF;
                 }
-                phi_copies[num_phi_copies].pred_block = (uint16_t)pairs[p];
-                phi_copies[num_phi_copies].phi_inst   = (uint16_t)idx;
-                phi_copies[num_phi_copies].src_val    = pairs[p + 1];
-                num_phi_copies++;
+                phicp[nphicp].pred_block = (uint16_t)pairs[p];
+                phicp[nphicp].phi_inst   = (uint16_t)idx;
+                phicp[nphicp].src_val    = pairs[p + 1];
+                nphicp++;
             }
         }
     }
@@ -554,7 +578,7 @@ static int phi_collect(const bir_module_t *M, const bir_func_t *F)
  * in a future sitting; flagging it cleanly is the right thing
  * until that work lands.
  */
-static int emit_phi_copies_for_pred(const bir_module_t *M,
+static int ephicp(const bir_module_t *M,
                                     uint16_t pred_block, rv_buf_t *out)
 {
     static uint8_t written[ISEL_MAX_INSTS];
@@ -562,15 +586,15 @@ static int emit_phi_copies_for_pred(const bir_module_t *M,
      * full memset every block would be wasteful. We walk the
      * batch twice: once to mark dests, once to emit; conflict
      * detection happens during the emit pass. */
-    for (uint32_t p = 0; p < num_phi_copies; p++) {
-        if (phi_copies[p].pred_block != pred_block) continue;
-        if (phi_copies[p].phi_inst >= ISEL_MAX_INSTS) continue;
-        written[phi_copies[p].phi_inst] = 0;
+    for (uint32_t p = 0; p < nphicp; p++) {
+        if (phicp[p].pred_block != pred_block) continue;
+        if (phicp[p].phi_inst >= ISEL_MAX_INSTS) continue;
+        written[phicp[p].phi_inst] = 0;
     }
 
-    for (uint32_t p = 0; p < num_phi_copies; p++) {
-        if (phi_copies[p].pred_block != pred_block) continue;
-        uint32_t src = phi_copies[p].src_val;
+    for (uint32_t p = 0; p < nphicp; p++) {
+        if (phicp[p].pred_block != pred_block) continue;
+        uint32_t src = phicp[p].src_val;
         if (!BIR_VAL_IS_CONST(src)) {
             uint32_t sidx = BIR_VAL_INDEX(src);
             if (sidx < ISEL_MAX_INSTS && written[sidx]) {
@@ -582,12 +606,12 @@ static int emit_phi_copies_for_pred(const bir_module_t *M,
                 return BC_ERR_TDF;
             }
         }
-        int rc = load_operand(M, src, RV_T0, out);
+        int rc = ldopnd(M, src, RV_T0, out);
         if (rc != BC_OK) return rc;
-        if ((rc = store_result(RV_T0, phi_copies[p].phi_inst, out)) != BC_OK)
+        if ((rc = stres(RV_T0, phicp[p].phi_inst, out)) != BC_OK)
             return rc;
-        if (phi_copies[p].phi_inst < ISEL_MAX_INSTS)
-            written[phi_copies[p].phi_inst] = 1;
+        if (phicp[p].phi_inst < ISEL_MAX_INSTS)
+            written[phicp[p].phi_inst] = 1;
     }
     return BC_OK;
 }
@@ -602,9 +626,72 @@ static int sel_br(const bir_module_t *M, uint16_t cur_block,
         fprintf(stderr, "rv_isel: BR with no target\n");
         return BC_ERR_TDF;
     }
-    int rc = emit_phi_copies_for_pred(M, cur_block, out);
+    int rc = ephicp(M, cur_block, out);
     if (rc != BC_OK) return rc;
-    return emit_jal_to_block((uint16_t)I->operands[0], out);
+    return ejalbk((uint16_t)I->operands[0], out);
+}
+
+/* Operand count, resolving the overflow indirection. */
+static uint32_t nopnd(const bir_inst_t *I)
+{
+    return I->num_operands == BIR_OPERANDS_OVERFLOW
+         ? I->operands[1] : I->num_operands;
+}
+
+/* Operand j, resolving the overflow indirection. Returns BIR_VAL_NONE if the
+ * index is out of range, which every caller must treat as malformed. */
+static uint32_t opnd(const bir_module_t *M, const bir_inst_t *I, uint32_t j)
+{
+    if (j >= nopnd(I)) return BIR_VAL_NONE;
+    if (I->num_operands != BIR_OPERANDS_OVERFLOW) return I->operands[j];
+    uint32_t k = I->operands[0] + j;
+    if (k >= M->num_extra_ops) return BIR_VAL_NONE;
+    return M->extra_operands[k];
+}
+
+/*
+ * Switch: operand 0 is the selector, 1 the default block, then (value, block)
+ * pairs. We emit a compare chain rather than a jump table, since the case
+ * values are arbitrary and a table would need a relocated base address that
+ * XIP would have to rewrite.
+ *
+ * Each case subtracts its value from the selector and branches on zero, which
+ * reuses the BEQ-against-zero patch the block patcher already knows how to
+ * resolve instead of needing a two-register branch form.
+ */
+static int sel_switch(const bir_module_t *M, uint16_t cur_block,
+                      const bir_inst_t *I, rv_buf_t *out)
+{
+    uint32_t n = nopnd(I);
+    if (n < 2u || (n & 1u) != 0u) {
+        fprintf(stderr,
+                "rv_isel: SWITCH needs a selector, a default and whole "
+                "(value, block) pairs, got %u operands\n", n);
+        return BC_ERR_TDF;
+    }
+    uint32_t sel = opnd(M, I, 0);
+    uint32_t dflt = opnd(M, I, 1);
+    if (sel == BIR_VAL_NONE || dflt == BIR_VAL_NONE) {
+        fprintf(stderr, "rv_isel: SWITCH operands out of range\n");
+        return BC_ERR_TDF;
+    }
+
+    int rc = ephicp(M, cur_block, out);
+    if (rc != BC_OK) return rc;
+
+    for (uint32_t j = 2u; j + 1u < n; j += 2u) {
+        uint32_t cval = opnd(M, I, j);
+        uint32_t cblk = opnd(M, I, j + 1u);
+        if (cval == BIR_VAL_NONE || cblk == BIR_VAL_NONE) {
+            fprintf(stderr, "rv_isel: SWITCH case %u out of range\n", j);
+            return BC_ERR_TDF;
+        }
+        if ((rc = ldopnd(M, sel, RV_T0, out)) != BC_OK) return rc;
+        if ((rc = ldopnd(M, cval, RV_T1, out)) != BC_OK) return rc;
+        if ((rc = emit(out, rv_sub(RV_T0, RV_T0, RV_T1))) != BC_OK) return rc;
+        if ((rc = ebrcond((uint16_t)cblk, RV_T0, 0, out)) != BC_OK) return rc;
+    }
+    return ejalbk((uint16_t)dflt, out);
 }
 
 static int sel_br_cond(const bir_module_t *M, uint16_t cur_block,
@@ -620,13 +707,13 @@ static int sel_br_cond(const bir_module_t *M, uint16_t cur_block,
         fprintf(stderr, "rv_isel: BR_COND needs cond + true + false\n");
         return BC_ERR_TDF;
     }
-    int rc = load_operand(M, I->operands[0], RV_T0, out);
+    int rc = ldopnd(M, I->operands[0], RV_T0, out);
     if (rc != BC_OK) return rc;
-    if ((rc = emit_phi_copies_for_pred(M, cur_block, out)) != BC_OK) return rc;
+    if ((rc = ephicp(M, cur_block, out)) != BC_OK) return rc;
     /* BNE T0, zero, true_block; JAL zero, false_block. */
-    if ((rc = emit_br_cond((uint16_t)I->operands[1], RV_T0, 1, out)) != BC_OK)
+    if ((rc = ebrcond((uint16_t)I->operands[1], RV_T0, 1, out)) != BC_OK)
         return rc;
-    return emit_jal_to_block((uint16_t)I->operands[2], out);
+    return ejalbk((uint16_t)I->operands[2], out);
 }
 
 /* ---- Select ----
@@ -647,18 +734,18 @@ static int sel_select(const bir_module_t *M, uint32_t inst_idx,
     int rc;
     /* Load condition into T2 so we can keep T0/T1 free for the
      * value loads. */
-    if ((rc = load_operand(M, I->operands[0], RV_T2, out)) != BC_OK) return rc;
+    if ((rc = ldopnd(M, I->operands[0], RV_T2, out)) != BC_OK) return rc;
     /* Materialise the false value into T0 first. */
-    if ((rc = load_operand(M, I->operands[2], RV_T0, out)) != BC_OK) return rc;
+    if ((rc = ldopnd(M, I->operands[2], RV_T0, out)) != BC_OK) return rc;
     /* BEQ T2, zero, +N to skip past the true-arm load if cond is 0.
-     * The true arm is the next op's load_operand which can be 1 or
+     * The true arm is the next op's ldopnd which can be 1 or
      * more instructions (constant materialisation may use LUI+ADDI).
      * Easiest: emit BEQ to a placeholder, load the true value,
      * back-patch the BEQ offset once we know how big the true arm is. */
     int beq_slot = rv_buf_emit(out, 0u);
     if (beq_slot < 0) return BC_ERR_OVERFLOW;
     uint32_t before_true = rv_buf_n_words(out);
-    if ((rc = load_operand(M, I->operands[1], RV_T0, out)) != BC_OK) return rc;
+    if ((rc = ldopnd(M, I->operands[1], RV_T0, out)) != BC_OK) return rc;
     uint32_t after_true = rv_buf_n_words(out);
     int32_t skip_bytes = (int32_t)(after_true - before_true) * 4 + 4;
     /* +4 because the branch is at beq_slot and we want to skip to
@@ -670,7 +757,7 @@ static int sel_select(const bir_module_t *M, uint32_t inst_idx,
     if (rv_buf_patch(out, (uint32_t)beq_slot,
                      rv_beq(RV_T2, RV_ZERO, (int16_t)skip_bytes)) != 0)
         return BC_ERR_TDF;
-    return store_result(RV_T0, inst_idx, out);
+    return stres(RV_T0, inst_idx, out);
 }
 
 /* ---- Function calls ----
@@ -702,7 +789,7 @@ static int sel_call(const bir_module_t *M, uint32_t inst_idx,
                 callee, ISEL_MAX_FUNCS);
         return BC_ERR_TDF;
     }
-    if (callee == current_func_idx) {
+    if (callee == curfn) {
         /* Direct recursion would clobber the saved ra in our
          * one-slot prologue. A real recursion story needs a
          * deeper save area; until then, refusing is correct. */
@@ -722,7 +809,7 @@ static int sel_call(const bir_module_t *M, uint32_t inst_idx,
     /* Load each arg into the corresponding a-register. RISC-V
      * psABI says first arg in a0, second in a1, and so on. */
     for (uint32_t i = 0; i < nargs; i++) {
-        int rc = load_operand(M, I->operands[i + 1u],
+        int rc = ldopnd(M, I->operands[i + 1u],
                               (uint8_t)(RV_A0 + i), out);
         if (rc != BC_OK) return rc;
     }
@@ -731,21 +818,21 @@ static int sel_call(const bir_module_t *M, uint32_t inst_idx,
      * realistic function distance within a single ELF. */
     int jal_slot = rv_buf_emit(out, 0u);
     if (jal_slot < 0) return BC_ERR_OVERFLOW;
-    if (num_call_patches >= ISEL_MAX_CALLS) {
+    if (ncalpat >= ISEL_MAX_CALLS) {
         fprintf(stderr,
                 "rv_isel: call patch table full at %u entries\n",
                 ISEL_MAX_CALLS);
         return BC_ERR_TDF;
     }
-    call_patches[num_call_patches].jal_word_idx = (uint32_t)jal_slot;
-    call_patches[num_call_patches].callee_func  = callee;
-    num_call_patches++;
+    calpat[ncalpat].jal_word_idx = (uint32_t)jal_slot;
+    calpat[ncalpat].callee_func  = callee;
+    ncalpat++;
 
     /* Spill return value (in a0) to this instruction's slot, if
      * the call produces a result. A void call has no result slot
      * to write to, which is fine; the slot for BIR_CALL's inst
      * is simply never read. */
-    return store_result(RV_A0, inst_idx, out);
+    return stres(RV_A0, inst_idx, out);
 }
 
 /* ---- Unreachable ----
@@ -756,24 +843,62 @@ static int sel_call(const bir_module_t *M, uint32_t inst_idx,
  * cores, which is actually closer to the BIR meaning (the
  * compiler thinks this code is unreachable; if execution gets
  * here, something is wrong and we want to halt for inspection). */
-static int sel_unreachable(rv_buf_t *out)
+static int sel_unrch(rv_buf_t *out)
 {
     return emit(out, rv_ebreak());
+}
+
+static uint32_t tybytes(const bir_module_t *M, uint32_t ti);
+
+/* Access width in bytes from the pointer's pointee type. Returns 0 when the
+ * type is not a pointer we can size, which is what an untyped pointer into L1
+ * looks like, and the caller then assumes a word. Widths we cannot express in
+ * one RV32 access come back as-is so the caller can refuse. */
+static uint32_t accwid(const bir_module_t *M, uint32_t ptr_val)
+{
+    if (BIR_VAL_IS_CONST(ptr_val)) return 0u;
+    uint32_t idx = BIR_VAL_INDEX(ptr_val);
+    if (idx >= M->num_insts) return 0u;
+    uint32_t pt = M->insts[idx].type;
+    if (pt >= M->num_types || M->types[pt].kind != BIR_TYPE_PTR) return 0u;
+    return tybytes(M, M->types[pt].inner);
+}
+
+/* Pick the load or store for an access width, or refuse. An i64 or an
+ * aggregate would otherwise compile to a 4-byte access and quietly read or
+ * write the wrong number of bytes. */
+static int winsn(uint32_t w, int is_load, uint32_t *insn)
+{
+    switch (w) {
+    case 0u:  /* unsizable pointee; assume a word, as the isel always has */
+    case 4u: *insn = is_load ? rv_lw (RV_T0, RV_T1, 0) : rv_sw(RV_T0, RV_T1, 0); return BC_OK;
+    case 2u: *insn = is_load ? rv_lhu(RV_T0, RV_T1, 0) : rv_sh(RV_T0, RV_T1, 0); return BC_OK;
+    case 1u: *insn = is_load ? rv_lbu(RV_T0, RV_T1, 0) : rv_sb(RV_T0, RV_T1, 0); return BC_OK;
+    default:
+        fprintf(stderr,
+                "rv_isel: %u-byte %s has no single RV32 access; i64 and "
+                "aggregate memory operations are not supported\n",
+                w, is_load ? "load" : "store");
+        return BC_ERR_TDF;
+    }
 }
 
 static int sel_load(const bir_module_t *M, uint32_t inst_idx,
                     const bir_inst_t *I, rv_buf_t *out)
 {
-    /* BIR_LOAD has ops[0] = address. We trust the front end to have
-     * produced i32-aligned addresses; if it didn't, the baby core
-     * silently rounds down per BabyRISCV README, which is exactly
-     * the kind of quiet bug worth never tolerating in production,
-     * but the bring-up isel cannot enforce alignment without type
-     * info we are not yet propagating here. */
-    int rc = load_operand(M, I->operands[0], RV_T1, out);
+    /* BIR_LOAD has ops[0] = address. Sub-word loads zero-extend; BIR carries no
+     * signedness on the type, so a sign-extending source arrives as an explicit
+     * BIR_SEXT, which re-derives the sign from the low bits anyway.
+     *
+     * Alignment is still the front end's problem. A misaligned address makes
+     * the baby core round down silently, per the BabyRISCV README, and we have
+     * no type info here to catch it. */
+    int rc = ldopnd(M, I->operands[0], RV_T1, out);
     if (rc != BC_OK) return rc;
-    if ((rc = emit(out, rv_lw(RV_T0, RV_T1, 0))) != BC_OK) return rc;
-    return store_result(RV_T0, inst_idx, out);
+    uint32_t insn;
+    if ((rc = winsn(accwid(M, I->operands[0]), 1, &insn)) != BC_OK) return rc;
+    if ((rc = emit(out, insn)) != BC_OK) return rc;
+    return stres(RV_T0, inst_idx, out);
 }
 
 static int sel_store(const bir_module_t *M,
@@ -783,9 +908,12 @@ static int sel_store(const bir_module_t *M,
      * note in the Booth codebase: store operand order is
      * value, address, NOT address, value). */
     int rc;
-    if ((rc = load_operand(M, I->operands[0], RV_T0, out)) != BC_OK) return rc;
-    if ((rc = load_operand(M, I->operands[1], RV_T1, out)) != BC_OK) return rc;
-    return emit(out, rv_sw(RV_T0, RV_T1, 0));
+    if ((rc = ldopnd(M, I->operands[0], RV_T0, out)) != BC_OK) return rc;
+    if ((rc = ldopnd(M, I->operands[1], RV_T1, out)) != BC_OK) return rc;
+    /* Narrow stores must not write the adjacent bytes. */
+    uint32_t insn;
+    if ((rc = winsn(accwid(M, I->operands[1]), 0, &insn)) != BC_OK) return rc;
+    return emit(out, insn);
 }
 
 /*
@@ -801,14 +929,14 @@ static int sel_store(const bir_module_t *M,
  * matching the standard C ABI convention. Anything wider than 4
  * bytes (we have no i64 yet on baby cores) clamps to word align.
  */
-static uint32_t nat_align(uint32_t sz)
+static uint32_t natalg(uint32_t sz)
 {
     if (sz >= 4u) return 4u;
     if (sz >= 2u) return 2u;
     return 1u;
 }
 
-static uint32_t align_up(uint32_t x, uint32_t a)
+static uint32_t algnup(uint32_t x, uint32_t a)
 {
     return (x + (a - 1u)) & ~(a - 1u);
 }
@@ -823,7 +951,7 @@ static uint32_t align_up(uint32_t x, uint32_t a)
  * contains a FUNC or an as-yet-unhandled type kind). Callers must
  * check and refuse rather than silently computing a wrong offset.
  */
-static uint32_t type_bytes(const bir_module_t *M, uint32_t ti)
+static uint32_t tybytes(const bir_module_t *M, uint32_t ti)
 {
     if (ti >= M->num_types) return 0u;
     const bir_type_t *t = &M->types[ti];
@@ -833,12 +961,12 @@ static uint32_t type_bytes(const bir_module_t *M, uint32_t ti)
     case BIR_TYPE_BFLOAT: return 2u;
     case BIR_TYPE_PTR:    return 4u;
     case BIR_TYPE_ARRAY: {
-        uint32_t es = type_bytes(M, t->inner);
+        uint32_t es = tybytes(M, t->inner);
         if (es == 0u) return 0u;
         return es * t->count;
     }
     case BIR_TYPE_VECTOR: {
-        uint32_t es = type_bytes(M, t->inner);
+        uint32_t es = tybytes(M, t->inner);
         if (es == 0u) return 0u;
         return es * (uint32_t)t->width;     /* width = lane count for VECTOR */
     }
@@ -847,9 +975,9 @@ static uint32_t type_bytes(const bir_module_t *M, uint32_t ti)
         for (uint16_t i = 0; i < t->num_fields; i++) {
             if (t->count + i >= M->num_type_fields) return 0u;
             uint32_t ft = M->type_fields[t->count + i];
-            uint32_t fs = type_bytes(M, ft);
+            uint32_t fs = tybytes(M, ft);
             if (fs == 0u) return 0u;
-            off = align_up(off, nat_align(fs)) + fs;
+            off = algnup(off, natalg(fs)) + fs;
         }
         return off;                         /* no tail padding for now */
     }
@@ -860,11 +988,11 @@ static uint32_t type_bytes(const bir_module_t *M, uint32_t ti)
 
 /*
  * Byte offset of field `fi` inside a STRUCT type, applying natural
- * alignment to each preceding field. Mirrors the type_bytes layout
+ * alignment to each preceding field. Mirrors the tybytes layout
  * walker exactly so the struct's overall layout and any per-field
  * GEP agree on where each field sits.
  */
-static uint32_t struct_field_offset(const bir_module_t *M,
+static uint32_t sfldof(const bir_module_t *M,
                                     uint32_t struct_ti,
                                     uint32_t fi)
 {
@@ -876,14 +1004,14 @@ static uint32_t struct_field_offset(const bir_module_t *M,
     for (uint16_t i = 0; i < (uint16_t)fi; i++) {
         if (t->count + i >= M->num_type_fields) return 0u;
         uint32_t ft = M->type_fields[t->count + i];
-        uint32_t fs = type_bytes(M, ft);
+        uint32_t fs = tybytes(M, ft);
         if (fs == 0u) return 0u;
-        off = align_up(off, nat_align(fs)) + fs;
+        off = algnup(off, natalg(fs)) + fs;
     }
     /* Align the START of the requested field to its own boundary. */
     if (t->count + fi < M->num_type_fields) {
-        uint32_t cur = type_bytes(M, M->type_fields[t->count + fi]);
-        if (cur != 0u) off = align_up(off, nat_align(cur));
+        uint32_t cur = tybytes(M, M->type_fields[t->count + fi]);
+        if (cur != 0u) off = algnup(off, natalg(cur));
     }
     return off;
 }
@@ -895,7 +1023,7 @@ static uint32_t struct_field_offset(const bir_module_t *M,
  * GEP base, but we handle it defensively rather than dereferencing
  * out of range).
  */
-static uint32_t base_pointee_type(const bir_module_t *M, uint32_t val)
+static uint32_t basety(const bir_module_t *M, uint32_t val)
 {
     if (BIR_VAL_IS_CONST(val)) return 0u;
     uint32_t idx = BIR_VAL_INDEX(val);
@@ -914,7 +1042,7 @@ static uint32_t base_pointee_type(const bir_module_t *M, uint32_t val)
  * LUI+ADDI and uses an ADD. Used by both the struct-field and the
  * array-stride paths so the encoding choices live in one place.
  */
-static int gep_add_byte_offset(int64_t off, rv_buf_t *out)
+static int gepoff(int64_t off, rv_buf_t *out)
 {
     if (off == 0) return BC_OK;
     if (off >= -2048 && off <= 2047) {
@@ -927,7 +1055,7 @@ static int gep_add_byte_offset(int64_t off, rv_buf_t *out)
         return BC_ERR_TDF;
     }
     int rc;
-    if ((rc = load_imm32(RV_T1, (int32_t)off, out)) != BC_OK) return rc;
+    if ((rc = ldimm32(RV_T1, (int32_t)off, out)) != BC_OK) return rc;
     return emit(out, rv_add(RV_T0, RV_T0, RV_T1));
 }
 
@@ -957,7 +1085,7 @@ static int sel_gep(const bir_module_t *M, uint32_t inst_idx,
         return BC_ERR_TDF;
     }
 
-    int rc = load_operand(M, I->operands[0], RV_T0, out);
+    int rc = ldopnd(M, I->operands[0], RV_T0, out);
     if (rc != BC_OK) return rc;
 
     /* Identify the base's pointee type. A struct-field GEP has a
@@ -968,7 +1096,7 @@ static int sel_gep(const bir_module_t *M, uint32_t inst_idx,
      * struct, and the index is a byte multiplier rather than a
      * field number. The two are distinguished by the front end's
      * encoding choice and we honour that here. */
-    uint32_t base_pointee = base_pointee_type(M, I->operands[0]);
+    uint32_t base_pointee = basety(M, I->operands[0]);
     uint32_t result_pointee = M->types[I->type].inner;
     int is_struct_gep = (base_pointee != 0u &&
                          base_pointee < M->num_types &&
@@ -996,7 +1124,7 @@ static int sel_gep(const bir_module_t *M, uint32_t inst_idx,
          * short-circuit before computing elem_size. This unblocks
          * the common "gep base, 0" idiom that bir_lower emits as
          * the first step of a struct member chain. */
-        if (idx_v == 0) return store_result(RV_T0, inst_idx, out);
+        if (idx_v == 0) return stres(RV_T0, inst_idx, out);
 
         int64_t off;
         if (is_struct_gep) {
@@ -1006,18 +1134,18 @@ static int sel_gep(const bir_module_t *M, uint32_t inst_idx,
                         (long long)idx_v);
                 return BC_ERR_TDF;
             }
-            off = (int64_t)struct_field_offset(M, base_pointee,
+            off = (int64_t)sfldof(M, base_pointee,
                                                (uint32_t)idx_v);
         } else {
-            uint32_t elem_sz = type_bytes(M, M->types[I->type].inner);
+            uint32_t elem_sz = tybytes(M, M->types[I->type].inner);
             if (elem_sz == 0u) {
                 fprintf(stderr, "rv_isel: unknown GEP pointee size\n");
                 return BC_ERR_TDF;
             }
             off = idx_v * (int64_t)elem_sz;
         }
-        if ((rc = gep_add_byte_offset(off, out)) != BC_OK) return rc;
-        return store_result(RV_T0, inst_idx, out);
+        if ((rc = gepoff(off, out)) != BC_OK) return rc;
+        return stres(RV_T0, inst_idx, out);
     }
 
     /* Non-constant index path: stride lowering only. Field-index
@@ -1030,18 +1158,18 @@ static int sel_gep(const bir_module_t *M, uint32_t inst_idx,
                 "rv_isel: non-constant struct GEP index is illegal\n");
         return BC_ERR_TDF;
     }
-    uint32_t elem_sz = type_bytes(M, M->types[I->type].inner);
+    uint32_t elem_sz = tybytes(M, M->types[I->type].inner);
     if (elem_sz == 0u) {
         fprintf(stderr, "rv_isel: unknown GEP pointee size\n");
         return BC_ERR_TDF;
     }
-    if ((rc = load_operand(M, I->operands[1], RV_T1, out)) != BC_OK) return rc;
+    if ((rc = ldopnd(M, I->operands[1], RV_T1, out)) != BC_OK) return rc;
     if (elem_sz != 1u) {
-        if ((rc = load_imm32(RV_T2, (int32_t)elem_sz, out)) != BC_OK) return rc;
+        if ((rc = ldimm32(RV_T2, (int32_t)elem_sz, out)) != BC_OK) return rc;
         if ((rc = emit(out, rv_mul(RV_T1, RV_T1, RV_T2))) != BC_OK) return rc;
     }
     if ((rc = emit(out, rv_add(RV_T0, RV_T0, RV_T1))) != BC_OK) return rc;
-    return store_result(RV_T0, inst_idx, out);
+    return stres(RV_T0, inst_idx, out);
 }
 
 /*
@@ -1050,7 +1178,7 @@ static int sel_gep(const bir_module_t *M, uint32_t inst_idx,
  * specifically so this is one instruction; if it ever moves we
  * need either a LUI+ADDI pair or a different free register slot.
  */
-static int load_rtarg_base(uint8_t reg, rv_buf_t *out)
+static int ldrtarg(uint8_t reg, rv_buf_t *out)
 {
     return emit(out, rv_lui(reg, TD_L1_RTARG_BASE >> 12));
 }
@@ -1073,10 +1201,10 @@ static int sel_param(uint32_t inst_idx, const bir_inst_t *I, rv_buf_t *out)
         return BC_ERR_TDF;
     }
     int rc;
-    if ((rc = load_rtarg_base(RV_T1, out)) != BC_OK) return rc;
+    if ((rc = ldrtarg(RV_T1, out)) != BC_OK) return rc;
     if ((rc = emit(out, rv_lw(RV_T0, RV_T1,
             (int16_t)RT_ARG_OFF_KARG(pi)))) != BC_OK) return rc;
-    return store_result(RV_T0, inst_idx, out);
+    return stres(RV_T0, inst_idx, out);
 }
 
 /*
@@ -1088,7 +1216,7 @@ static int sel_param(uint32_t inst_idx, const bir_inst_t *I, rv_buf_t *out)
  * model means threadIdx is always (0,0,0) and the launcher records
  * exactly that.
  */
-static int sel_intrinsic(uint32_t inst_idx, const bir_inst_t *I, rv_buf_t *out)
+static int sel_intrin(uint32_t inst_idx, const bir_inst_t *I, rv_buf_t *out)
 {
     uint8_t dim = I->subop;
     if (dim > 2u) {
@@ -1107,9 +1235,9 @@ static int sel_intrinsic(uint32_t inst_idx, const bir_inst_t *I, rv_buf_t *out)
         return BC_ERR_TDF;
     }
     int rc;
-    if ((rc = load_rtarg_base(RV_T1, out)) != BC_OK) return rc;
+    if ((rc = ldrtarg(RV_T1, out)) != BC_OK) return rc;
     if ((rc = emit(out, rv_lw(RV_T0, RV_T1, (int16_t)off))) != BC_OK) return rc;
-    return store_result(RV_T0, inst_idx, out);
+    return stres(RV_T0, inst_idx, out);
 }
 
 
@@ -1118,7 +1246,12 @@ static int sel_ret(const bir_module_t *M, uint32_t frame_sz,
 {
     int rc;
     if (I->num_operands > 0u) {
-        if ((rc = load_operand(M, I->operands[0], RV_A0, out)) != BC_OK) return rc;
+        if ((rc = ldopnd(M, I->operands[0], RV_A0, out)) != BC_OK) return rc;
+    } else {
+        /* tt-metal calls the kernel entry as uint32_t(*)() and feeds a0 to
+         * record_stack_usage, where zero means "not computed". Leaving a0
+         * dirty would report a bogus watermark. */
+        if ((rc = emit(out, rv_addi(RV_A0, RV_ZERO, 0))) != BC_OK) return rc;
     }
     /* Epilogue: restore ra, deallocate the frame, jalr to ra. */
     if ((rc = emit(out, rv_lw(RV_RA, RV_SP, 0))) != BC_OK) return rc;
@@ -1138,14 +1271,21 @@ int rv_isel_func(const bir_module_t *M, uint32_t func_idx,
     }
     /* Record this function's starting position so any other
      * function in the same module that calls into us can patch
-     * the JAL offset later. current_func_idx tracks which function
+     * the JAL offset later. curfn tracks which function
      * we're emitting so sel_call can detect direct recursion. */
     if (func_idx < ISEL_MAX_FUNCS) {
-        func_word_idx[func_idx] = rv_buf_n_words(out);
-        func_known[func_idx] = 1;
+        fnwidx[func_idx] = rv_buf_n_words(out);
+        fnknwn[func_idx] = 1;
     }
-    current_func_idx = (uint16_t)func_idx;
+    curfn = (uint16_t)func_idx;
     const bir_func_t *F = &M->funcs[func_idx];
+
+    /* Instruction indices are module-global, so bias them by this function's
+     * first one to get frame-local slot numbers. */
+    slotbas = 0;
+    if (F->num_blocks > 0u && F->first_block < M->num_blocks) {
+        slotbas = M->blocks[F->first_block].first_inst;
+    }
 
     if (F->total_insts > ISEL_MAX_INSTS) {
         fprintf(stderr,
@@ -1159,8 +1299,8 @@ int rv_isel_func(const bir_module_t *M, uint32_t func_idx,
      * emit pass so the frame size includes both the per-inst slots
      * and the alloca region, and the main pass can hand each
      * BIR_ALLOCA its absolute frame offset. */
-    static uint32_t alloca_off[ISEL_MAX_INSTS];
-    uint32_t alloca_total = 0;
+    static uint32_t alcoff[ISEL_MAX_INSTS];
+    uint32_t alctot = 0;
     for (uint32_t bi = 0; bi < F->num_blocks; bi++) {
         uint32_t bk = F->first_block + bi;
         if (bk >= M->num_blocks) break;
@@ -1169,7 +1309,8 @@ int rv_isel_func(const bir_module_t *M, uint32_t func_idx,
             uint32_t idx = B->first_inst + ii;
             const bir_inst_t *I = &M->insts[idx];
             if (I->op != BIR_ALLOCA) continue;
-            if (idx >= ISEL_MAX_INSTS) {
+            uint32_t lidx = idx - slotbas;
+            if (lidx >= ISEL_MAX_INSTS) {
                 fprintf(stderr,
                         "rv_isel: alloca at idx %u past table\n", idx);
                 return BC_ERR_TDF;
@@ -1178,12 +1319,54 @@ int rv_isel_func(const bir_module_t *M, uint32_t func_idx,
             uint32_t pointee_sz = 0;
             if (I->type < M->num_types &&
                 M->types[I->type].kind == BIR_TYPE_PTR) {
-                pointee_sz = type_bytes(M, M->types[I->type].inner);
+                pointee_sz = tybytes(M, M->types[I->type].inner);
             }
             if (pointee_sz == 0u) pointee_sz = 4u;  /* default i32-shaped */
-            alloca_total = round_up(alloca_total, ISEL_ALLOCA_ALIGN);
-            alloca_off[idx] = alloca_total;
-            alloca_total += pointee_sz;
+            alctot = rndup(alctot, ISEL_ALLOCA_ALIGN);
+            alcoff[lidx] = alctot;
+            alctot += pointee_sz;
+        }
+    }
+
+    /* Same walk for __shared__, but the region is a fixed slab at the top of
+     * L1 rather than stack, and it is laid out once per kernel because a baby
+     * core runs a single block. */
+    static uint32_t shoff[ISEL_MAX_INSTS];
+    uint32_t shtot = 0;
+    for (uint32_t bi = 0; bi < F->num_blocks; bi++) {
+        uint32_t bk = F->first_block + bi;
+        if (bk >= M->num_blocks) break;
+        const bir_block_t *B = &M->blocks[bk];
+        for (uint32_t ii = 0; ii < B->num_insts; ii++) {
+            uint32_t idx = B->first_inst + ii;
+            const bir_inst_t *I = &M->insts[idx];
+            if (I->op != BIR_SHARED_ALLOC) continue;
+            uint32_t lidx = idx - slotbas;
+            if (lidx >= ISEL_MAX_INSTS) {
+                fprintf(stderr,
+                        "rv_isel: shared_alloc at idx %u past table\n", idx);
+                return BC_ERR_TDF;
+            }
+            uint32_t sz = 0;
+            if (I->type < M->num_types &&
+                M->types[I->type].kind == BIR_TYPE_PTR) {
+                sz = tybytes(M, M->types[I->type].inner);
+            }
+            if (sz == 0u) {
+                fprintf(stderr,
+                        "rv_isel: shared_alloc at idx %u has unsizable "
+                        "pointee type\n", idx);
+                return BC_ERR_TDF;
+            }
+            shtot = rndup(shtot, TD_L1_ALIGN);
+            shoff[lidx] = shtot;
+            shtot += sz;
+            if (shtot > TD_L1_SHARED_SIZE) {
+                fprintf(stderr,
+                        "rv_isel: __shared__ needs %u bytes, slab is %u\n",
+                        shtot, TD_L1_SHARED_SIZE);
+                return BC_ERR_TDF;
+            }
         }
     }
 
@@ -1191,11 +1374,20 @@ int rv_isel_func(const bir_module_t *M, uint32_t func_idx,
      * slot + the alloca region, rounded up to the 16-byte alignment
      * the RISC-V soft-float psABI requires for the stack pointer
      * at function entry. */
-    uint32_t frame_sz = round_up(
-        ISEL_LOCALS_BASE + F->total_insts * 4u + alloca_total,
+    uint32_t frame_sz = rndup(
+        ISEL_LOCALS_BASE + F->total_insts * 4u + alctot,
         ISEL_FRAME_ALIGN);
     /* Alloca region starts immediately after the per-inst slots. */
-    uint32_t alloca_base = ISEL_LOCALS_BASE + F->total_insts * 4u;
+    uint32_t alcbase = ISEL_LOCALS_BASE + F->total_insts * 4u;
+
+    /* The prologue and epilogue adjust sp with a single ADDI, so the frame has
+     * to fit the 12-bit signed immediate. */
+    if (frame_sz > 2047u) {
+        fprintf(stderr,
+                "rv_isel: frame of %u bytes exceeds the ADDI immediate range\n",
+                frame_sz);
+        return BC_ERR_TDF;
+    }
 
     /* Prologue: drop sp, save ra. */
     int rc;
@@ -1209,8 +1401,8 @@ int rv_isel_func(const bir_module_t *M, uint32_t func_idx,
      * as the slot index since the BIR module is single-function in
      * the bring-up path; once multi-function lands this will need
      * a per-function renumbering. */
-    isel_reset_cf();
-    rc = phi_collect(M, F);
+    isel_rstcf();
+    rc = phicoll(M, F);
     if (rc != BC_OK) return rc;
     int saw_ret = 0;
     for (uint32_t bi = 0; bi < F->num_blocks; bi++) {
@@ -1219,8 +1411,8 @@ int rv_isel_func(const bir_module_t *M, uint32_t func_idx,
         /* Record where this block's first instruction lands in the
          * code buffer so subsequent branches to it can resolve. */
         if (bk < ISEL_MAX_BLOCKS) {
-            block_word_idx[bk] = rv_buf_n_words(out);
-            block_known[bk] = 1;
+            blkwidx[bk] = rv_buf_n_words(out);
+            blkknwn[bk] = 1;
         }
         const bir_block_t *B = &M->blocks[bk];
         for (uint32_t ii = 0; ii < B->num_insts; ii++) {
@@ -1234,7 +1426,7 @@ int rv_isel_func(const bir_module_t *M, uint32_t func_idx,
             case BIR_BLOCK_ID:
             case BIR_BLOCK_DIM:
             case BIR_GRID_DIM:
-                rc = sel_intrinsic(idx, I, out);
+                rc = sel_intrin(idx, I, out);
                 break;
             case BIR_LOAD:
                 rc = sel_load(M, idx, I, out);
@@ -1245,6 +1437,7 @@ int rv_isel_func(const bir_module_t *M, uint32_t func_idx,
             case BIR_ADD:
             case BIR_SUB:
             case BIR_MUL:
+            case BIR_UMULHI:
             case BIR_SDIV:
             case BIR_UDIV:
             case BIR_SREM:
@@ -1275,12 +1468,12 @@ int rv_isel_func(const bir_module_t *M, uint32_t func_idx,
                 rc = sel_trunc(M, idx, I, out);
                 break;
             case BIR_UNREACHABLE:
-                rc = sel_unreachable(out);
+                rc = sel_unrch(out);
                 break;
             case BIR_ALLOCA: {
-                /* Compute sp + alloca_base + alloca_off[idx], store
+                /* Compute sp + alcbase + alcoff[idx], store
                  * the resulting pointer into this inst's slot. */
-                uint32_t total = alloca_base + alloca_off[idx];
+                uint32_t total = alcbase + alcoff[idx - slotbas];
                 if (total > 2047u) {
                     fprintf(stderr,
                             "rv_isel: alloca offset %u out of ADDI range\n",
@@ -1289,19 +1482,52 @@ int rv_isel_func(const bir_module_t *M, uint32_t func_idx,
                     break;
                 }
                 rc = emit(out, rv_addi(RV_T0, RV_SP, (int16_t)total));
-                if (rc == BC_OK) rc = store_result(RV_T0, idx, out);
+                if (rc == BC_OK) rc = stres(RV_T0, idx, out);
                 break;
             }
+            case BIR_SHARED_ALLOC:
+                /* Absolute L1 address, materialised inline. No relocation is
+                 * involved: this is a data address, and XIP only rewrites
+                 * text-relative references. */
+                rc = ldimm32(RV_T0,
+                             (int32_t)(TD_L1_SHARED_BASE + shoff[idx - slotbas]),
+                             out);
+                if (rc == BC_OK) rc = stres(RV_T0, idx, out);
+                break;
             case BIR_BR:
                 rc = sel_br(M, (uint16_t)bk, I, out);
                 break;
             case BIR_BR_COND:
                 rc = sel_br_cond(M, (uint16_t)bk, I, out);
                 break;
+            case BIR_SWITCH:
+                rc = sel_switch(M, (uint16_t)bk, I, out);
+                break;
+            case BIR_GLOBAL_REF:
+                /* Computing the address is easy; the problem is that nothing
+                 * puts a value there. The ELF has one PT_LOAD and no .data,
+                 * and the kernel is a bare function that never runs a crt1 to
+                 * stage an image, so the pointer would reference uninitialised
+                 * L1. Even a zero-init global would be wrong. */
+                fprintf(stderr,
+                        "rv_isel: __device__ and __constant__ globals need a "
+                        "data segment and an initialisation path, neither of "
+                        "which this backend emits yet\n");
+                rc = BC_ERR_TDF;
+                break;
+            case BIR_BARRIER:
+            case BIR_BARRIER_GROUP:
+                /* A baby core is one hardware thread with no SIMT, so a
+                 * block-level barrier has nothing to wait on. FENCE is a
+                 * documented no-op here and would not order anything, so
+                 * emitting one would only mislead. Cross-core coordination
+                 * goes through CB semaphores, which is a different opcode. */
+                rc = BC_OK;
+                break;
             case BIR_PHI:
                 /* PHI emits no code in its own block; its slot is
                  * populated by predecessor blocks before they
-                 * branch here. See phi_collect / emit_phi_copies. */
+                 * branch here. See phicoll / emit_phi_copies. */
                 rc = BC_OK;
                 break;
             case BIR_CALL:
@@ -1340,17 +1566,17 @@ int rv_isel_func(const bir_module_t *M, uint32_t func_idx,
 
     /* Resolve any branches we deferred when we hit a forward
      * reference. By now every block we might branch to has been
-     * recorded in block_word_idx, so each patch turns into a single
+     * recorded in blkwidx, so each patch turns into a single
      * offset computation and a buffer rewrite. */
-    for (uint32_t p = 0; p < num_patches; p++) {
+    for (uint32_t p = 0; p < npatch; p++) {
         uint16_t tb = patches[p].target_block;
-        if (tb >= ISEL_MAX_BLOCKS || !block_known[tb]) {
+        if (tb >= ISEL_MAX_BLOCKS || !blkknwn[tb]) {
             fprintf(stderr,
                     "rv_isel: unresolved branch to block %u\n", tb);
             return BC_ERR_TDF;
         }
         int32_t off = rv_buf_offset(out, patches[p].word_idx,
-                                    block_word_idx[tb]);
+                                    blkwidx[tb]);
         uint32_t word;
         if (patches[p].kind == 2u) {
             if (off < -1048576 || off > 1048574) {
@@ -1401,25 +1627,50 @@ int rv_isel_module(const bir_module_t *M, rv_buf_t *out)
         return BC_ERR_TDF;
     }
 
-    isel_reset_module();
-
+    /* tt-metal enters a kernel by calling the first byte of .text, so the
+     * __global__ function has to be emitted first. Source order puts any
+     * __device__ helpers ahead of it, and emitting those first would run a
+     * helper as the kernel. */
+    uint32_t kfn = M->num_funcs;
+    uint32_t nglob = 0;
     for (uint32_t fi = 0; fi < M->num_funcs; fi++) {
-        int rc = rv_isel_func(M, fi, out);
+        if (!(M->funcs[fi].cuda_flags & CUDA_GLOBAL)) continue;
+        if (nglob == 0u) kfn = fi;
+        nglob++;
+    }
+    if (nglob == 0u) {
+        fprintf(stderr, "rv_isel: module has no __global__ kernel to enter\n");
+        return BC_ERR_TDF;
+    }
+    if (nglob > 1u) {
+        fprintf(stderr,
+                "rv_isel: module has %u __global__ kernels; entering the "
+                "first one. Split them into separate ELFs to pick another\n",
+                nglob);
+    }
+
+    isel_rstmod();
+
+    int rc = rv_isel_func(M, kfn, out);
+    if (rc != BC_OK) return rc;
+    for (uint32_t fi = 0; fi < M->num_funcs; fi++) {
+        if (fi == kfn) continue;
+        rc = rv_isel_func(M, fi, out);
         if (rc != BC_OK) return rc;
     }
 
     /* Resolve every call placeholder. By now every callee's
-     * starting position is in func_word_idx, so each patch is a
+     * starting position is in fnwidx, so each patch is a
      * single offset computation and a buffer rewrite. */
-    for (uint32_t p = 0; p < num_call_patches; p++) {
-        uint16_t cf = call_patches[p].callee_func;
-        if (cf >= ISEL_MAX_FUNCS || !func_known[cf]) {
+    for (uint32_t p = 0; p < ncalpat; p++) {
+        uint16_t cf = calpat[p].callee_func;
+        if (cf >= ISEL_MAX_FUNCS || !fnknwn[cf]) {
             fprintf(stderr,
                     "rv_isel: unresolved call to function %u\n", cf);
             return BC_ERR_TDF;
         }
-        int32_t off = rv_buf_offset(out, call_patches[p].jal_word_idx,
-                                    func_word_idx[cf]);
+        int32_t off = rv_buf_offset(out, calpat[p].jal_word_idx,
+                                    fnwidx[cf]);
         if (off < -1048576 || off > 1048574) {
             fprintf(stderr,
                     "rv_isel: call offset %d busts JAL range\n", off);
@@ -1429,7 +1680,7 @@ int rv_isel_module(const bir_module_t *M, rv_buf_t *out)
          * (x1) as the link register, not zero like the
          * branch-style jumps. */
         uint32_t word = rv_jal(RV_RA, off);
-        if (rv_buf_patch(out, call_patches[p].jal_word_idx, word) != 0)
+        if (rv_buf_patch(out, calpat[p].jal_word_idx, word) != 0)
             return BC_ERR_TDF;
     }
     return BC_OK;

--- a/src/tensix/rv_isel.c
+++ b/src/tensix/rv_isel.c
@@ -1506,7 +1506,8 @@ int rv_isel_func(const bir_module_t *M, uint32_t func_idx,
                  * involved: this is a data address, and XIP only rewrites
                  * text-relative references. */
                 rc = ldimm32(RV_T0,
-                             (int32_t)(TD_L1_SHARED_BASE + shoff[idx - slotbas]),
+                             (int32_t)(td_shbase(td_chip())
+                                       + shoff[idx - slotbas]),
                              out);
                 if (rc == BC_OK) rc = stres(RV_T0, idx, out);
                 break;

--- a/src/tensix/rv_isel.c
+++ b/src/tensix/rv_isel.c
@@ -418,6 +418,15 @@ static uint32_t instwid(const bir_module_t *M, const bir_inst_t *I)
     return 32u;
 }
 
+/* i64 does not fit an RV32 register. A 64-bit mul would keep only the low half,
+ * and a shift by 32 would shift by zero, since RV32 reads shamt[4:0]. */
+static int wide64(const bir_module_t *M, const bir_inst_t *I)
+{
+    if (I->type >= M->num_types) return 0;
+    const bir_type_t *t = &M->types[I->type];
+    return t->kind == BIR_TYPE_INT && t->width > 32u;
+}
+
 static int sel_zext(const bir_module_t *M, uint32_t inst_idx,
                     const bir_inst_t *I, rv_buf_t *out)
 {
@@ -1418,6 +1427,13 @@ int rv_isel_func(const bir_module_t *M, uint32_t func_idx,
         for (uint32_t ii = 0; ii < B->num_insts; ii++) {
             uint32_t idx = B->first_inst + ii;
             const bir_inst_t *I = &M->insts[idx];
+            if (wide64(M, I)) {
+                fprintf(stderr,
+                        "rv_isel: %u-bit integer result at inst %u has no RV32 "
+                        "representation; 64-bit arithmetic is not supported\n",
+                        instwid(M, I), idx);
+                return BC_ERR_TDF;
+            }
             switch (I->op) {
             case BIR_PARAM:
                 rc = sel_param(idx, I, out);

--- a/src/tensix/rv_isel.h
+++ b/src/tensix/rv_isel.h
@@ -16,13 +16,11 @@
  * point is to get a kernel running on the n300 first and improve once we
  * have something to measure.
  *
- * Today it handles parameters, i32 loads and stores through a pointer,
- * integer arithmetic with t0/t1 scratch, integer or void returns, and
- * small constants materialised via ADDI. It does not yet handle the
- * harder cases (calls, control flow, GEP, floats, vectors, structs), more
- * than 8 integer parameters, or constants outside the I-type 12-bit
- * signed range that would need LUI+ADDI. Spec sources are cited in the .c
- * file alongside each opcode emission.
+ * It handles parameters, integer arithmetic, comparisons, casts, control
+ * flow, PHI, GEP, alloca, calls, and loads and stores at 1, 2 or 4 bytes.
+ * It does not handle floats, atomics, warp primitives, aggregates or i64
+ * memory operations, and refuses each rather than emitting something
+ * plausible. Spec sources are cited in the .c file alongside each opcode.
  */
 
 /*
@@ -36,11 +34,13 @@ int rv_isel_func(const bir_module_t *M, uint32_t func_idx,
 /*
  * Select every function in the module, emitting them back-to-back
  * into the same code buffer. Used when the kernel calls into other
- * functions (e.g., a soft-float libcall) and those callees need to
- * live in the same ELF. Function 0 is emitted first by convention
- * because that is where the host loader sets the PC; everything
- * else is reachable via JAL with offsets resolved after the whole
- * module is laid out.
+ * functions and those callees need to live in the same ELF.
+ *
+ * The __global__ function is emitted first, not function 0. tt-metal
+ * enters a kernel by calling the first byte of .text, and source order
+ * puts any __device__ helpers ahead of the kernel, so emitting in index
+ * order would run a helper as the kernel. Everything else is reachable
+ * via JAL with offsets resolved after the whole module is laid out.
  *
  * Inter-function calls work by recording a patch when the JAL is
  * emitted, and filling in the offset once every callee's position

--- a/tests/rv_shared.cu
+++ b/tests/rv_shared.cu
@@ -1,0 +1,10 @@
+/* rv_shared.cu -- fixture for __shared__ lowering. The tile is placed in the
+ * L1 slab carved off the top, so the kernel must materialise an absolute
+ * address at TD_L1_SHARED_BASE rather than a stack offset. */
+
+__global__ void k(int *o) {
+    __shared__ int tile[64];
+    int t = threadIdx.x;
+    tile[t] = o[t] * 2;
+    o[t] = tile[t];
+}

--- a/tests/rv_switch.cu
+++ b/tests/rv_switch.cu
@@ -1,0 +1,15 @@
+/* rv_switch.cu -- fixture for the RV32 switch lowering. Three cases plus a
+ * default, so the isel must emit a three-deep compare chain and fall through
+ * to the default block. */
+
+__global__ void k(int *o) {
+    int t = threadIdx.x;
+    int r;
+    switch (t) {
+        case 0:  r = 10; break;
+        case 1:  r = 20; break;
+        case 7:  r = 30; break;
+        default: r = 99; break;
+    }
+    o[t] = r;
+}

--- a/tests/trv_buf.c
+++ b/tests/trv_buf.c
@@ -13,7 +13,7 @@ static void rv_buf_init_zero(void)
     memset(&B, 0xAB, sizeof(B));
     rv_buf_init(&B);
     CHEQ(rv_buf_n_words(&B), 0u);
-    CHEQ(rv_buf_pos_bytes(&B), 0u);
+    CHEQ(rv_buf_nbytes(&B), 0u);
     PASS();
 }
 TH_REG("rv_enc", rv_buf_init_zero);
@@ -30,7 +30,7 @@ static void rv_buf_emit_seq(void)
     CHEQ(i1, 1);
     CHEQ(i2, 2);
     CHEQ(rv_buf_n_words(&B), 3u);
-    CHEQ(rv_buf_pos_bytes(&B), 12u);
+    CHEQ(rv_buf_nbytes(&B), 12u);
     PASS();
 }
 TH_REG("rv_enc", rv_buf_emit_seq);

--- a/tests/trv_elf.c
+++ b/tests/trv_elf.c
@@ -289,7 +289,7 @@ static void rv_elf_segments_meta(void)
     uint32_t off = rd32(shdr(s) + 16);
     CHEQ(rd32(off + 0), RV_ELF_LOAD_ADDR);       /* vma */
     CHEQ(rd32(off + 4), RV_ELF_LOAD_ADDR);       /* trim_bound, so no trim */
-    CHEQ(rd32(off + 8), RV_ELF_TEXT_LIMIT);
+    CHEQ(rd32(off + 8), td_txtmax(td_chip()));
     PASS();
 }
 TH_REG("rv_enc", rv_elf_segments_meta);
@@ -617,7 +617,7 @@ static void e2e_rv_text_sane(void)
     uint32_t t = sfind(".text");
     uint32_t sz = rd32(shdr(t) + 20);
     CHEQ(sz % 4u, 0u);
-    CHECK(sz > 0u && sz <= RV_ELF_TEXT_LIMIT);
+    CHECK(sz > 0u && sz <= td_txtmax(td_chip()));
     PASS();
 }
 TH_REG("rv_enc", e2e_rv_text_sane);
@@ -654,7 +654,7 @@ static void e2e_rv_shared_addr(void)
     int found = 0;
     for (uint32_t i = 0; i < nw; i++) {
         uint32_t w = rd32(off + i * 4u);
-        if ((w & 0x7Fu) == 0x37u && ((w >> 12) << 12) == TD_L1_SHARED_BASE)
+        if ((w & 0x7Fu) == 0x37u && ((w >> 12) << 12) == td_shbase(td_chip()))
             found = 1;
     }
     CHECK(found);
@@ -666,8 +666,8 @@ TH_REG("rv_enc", e2e_rv_shared_addr);
  * true while the placer's ceiling is the slab base. */
 static void rv_l1_shared_below_end(void)
 {
-    CHECK(TD_L1_SHARED_BASE + TD_L1_SHARED_SIZE == TD_L1_END);
-    CHECK(TD_L1_CB_BASE < TD_L1_SHARED_BASE);
+    CHECK(td_shbase(td_chip()) + TD_L1_SHARED_SIZE == td_l1end(td_chip()));
+    CHECK(TD_L1_CB_BASE < td_shbase(td_chip()));
     PASS();
 }
 TH_REG("rv_enc", rv_l1_shared_below_end);

--- a/tests/trv_elf.c
+++ b/tests/trv_elf.c
@@ -6,6 +6,7 @@
 #include "rv_buf.h"
 #include "rv_enc.h"
 #include "rv_elf.h"
+#include "tdf.h"
 
 #define ELF_OUT  "tdf_test_kernel.elf"
 
@@ -128,9 +129,9 @@ static void rv_elf_pt_load(void)
     CHEQ(e_phoff, 52u);
     /* First PT_LOAD: p_type at e_phoff. */
     CHEQ(rd32(e_phoff + 0),  1u);              /* PT_LOAD */
-    /* p_offset: where code starts in the file, right after the
-     * 32-byte program header at 84. */
-    CHEQ(rd32(e_phoff + 4),  52u + 32u);
+    /* p_offset: 84 rounded up to the 16-byte segment alignment tt-metal
+     * links with (-Wl,-z,max-page-size=16). */
+    CHEQ(rd32(e_phoff + 4),  96u);
     /* p_vaddr equals the documented load address. */
     CHEQ(rd32(e_phoff + 8),  RV_ELF_LOAD_ADDR);
     /* p_filesz == p_memsz == 12 bytes (3 instructions). */
@@ -191,3 +192,482 @@ static void rv_elf_empty(void)
     PASS();
 }
 TH_REG("rv_enc", rv_elf_empty);
+
+/*
+ * The tests below encode tt-metal's loader contract from
+ * tt_metal/llrt/tt_elffile.cpp. Each one stands for a specific throw in
+ * ReadImage or XIPify.
+ */
+
+/* File offset of section header i. */
+static uint32_t shdr(uint32_t i)
+{
+    return rd32(32) + i * 40u;
+}
+
+/* Index of the section named n, or 0xFFFFFFFF. */
+static uint32_t sfind(const char *n)
+{
+    uint32_t nsec  = rd16(48);
+    uint32_t strsh = shdr(rd16(50));
+    uint32_t strb  = rd32(strsh + 16);
+    for (uint32_t i = 0; i < nsec; i++) {
+        const char *s = (const char *)&rd[strb + rd32(shdr(i))];
+        if (strcmp(s, n) == 0) return i;
+    }
+    return 0xFFFFFFFFu;
+}
+
+/* ReadImage:498 -- "first loadable segment is not text". */
+static void rv_elf_entry_is_first_seg(void)
+{
+    build_kernel();
+    rv_elf_write(&B, ELF_OUT);
+    slurp(ELF_OUT);
+    CHEQ(rd32(24), rd32(rd32(28) + 8));
+    PASS();
+}
+TH_REG("rv_enc", rv_elf_entry_is_first_seg);
+
+/* ReadImage:472 -- p_offset, p_vaddr and p_paddr share 4-byte alignment. */
+static void rv_elf_phdr_aligned(void)
+{
+    build_kernel();
+    rv_elf_write(&B, ELF_OUT);
+    slurp(ELF_OUT);
+    uint32_t ph = rd32(28);
+    CHEQ((rd32(ph + 4) | rd32(ph + 8) | rd32(ph + 12)) & 3u, 0u);
+    PASS();
+}
+TH_REG("rv_enc", rv_elf_phdr_aligned);
+
+/* ReadImage:435 -- sections and a valid nonzero shstrndx are mandatory. */
+static void rv_elf_has_sections(void)
+{
+    build_kernel();
+    rv_elf_write(&B, ELF_OUT);
+    slurp(ELF_OUT);
+    CHECK(rd32(32) != 0u);
+    CHEQ(rd16(46), 40u);
+    CHECK(rd16(50) != 0u);
+    CHECK(rd16(50) < rd16(48));
+    PASS();
+}
+TH_REG("rv_enc", rv_elf_has_sections);
+
+/* XIPify:1039 -- "there are no relocation sections". The section must be
+ * SHT_RELA, and sh_info must name an alloc section that lies inside a
+ * segment, else the loader skips it and the count stays zero. */
+static void rv_elf_rela_present(void)
+{
+    build_kernel();
+    rv_elf_write(&B, ELF_OUT);
+    slurp(ELF_OUT);
+    uint32_t r = sfind(".rela.text");
+    CHECK(r != 0xFFFFFFFFu);
+    CHEQ(rd32(shdr(r) + 4), 4u);                 /* SHT_RELA */
+    uint32_t tgt = rd32(shdr(r) + 28);           /* sh_info */
+    CHEQ(tgt, sfind(".text"));
+    CHEQ(rd32(shdr(tgt) + 8) & 2u, 2u);          /* target is SHF_ALLOC */
+    CHEQ(rd32(shdr(r) + 24), sfind(".symtab")); /* sh_link */
+    PASS();
+}
+TH_REG("rv_enc", rv_elf_rela_present);
+
+/* TrimSegments:545 -- matched by name, SHT_PROGBITS and NOT SHF_ALLOC,
+ * holding one (vma, trim_bound, size_limit) triple per segment. */
+static void rv_elf_segments_meta(void)
+{
+    build_kernel();
+    rv_elf_write(&B, ELF_OUT);
+    slurp(ELF_OUT);
+    uint32_t s = sfind(".segments");
+    CHECK(s != 0xFFFFFFFFu);
+    CHEQ(rd32(shdr(s) + 4), 1u);                 /* SHT_PROGBITS */
+    CHEQ(rd32(shdr(s) + 8) & 2u, 0u);            /* not SHF_ALLOC */
+    CHEQ(rd32(shdr(s) + 20), 12u);
+    uint32_t off = rd32(shdr(s) + 16);
+    CHEQ(rd32(off + 0), RV_ELF_LOAD_ADDR);       /* vma */
+    CHEQ(rd32(off + 4), RV_ELF_LOAD_ADDR);       /* trim_bound, so no trim */
+    CHEQ(rd32(off + 8), RV_ELF_TEXT_LIMIT);
+    PASS();
+}
+TH_REG("rv_enc", rv_elf_segments_meta);
+
+/* XIPify:779 resolves relocation symbols through the symtab, so it must
+ * exist and be non-alloc (WeakenDataSymbols skips alloc symtabs). */
+static void rv_elf_symtab(void)
+{
+    build_kernel();
+    rv_elf_write(&B, ELF_OUT);
+    slurp(ELF_OUT);
+    uint32_t y = sfind(".symtab");
+    CHECK(y != 0xFFFFFFFFu);
+    CHEQ(rd32(shdr(y) + 4), 2u);                 /* SHT_SYMTAB */
+    CHEQ(rd32(shdr(y) + 8) & 2u, 0u);            /* not SHF_ALLOC */
+    CHEQ(rd32(shdr(y) + 36), 16u);               /* sh_entsize */
+    CHEQ(rd32(shdr(y) + 24), sfind(".strtab"));  /* sh_link */
+    /* Entry 0 is the reserved null symbol. */
+    uint32_t off = rd32(shdr(y) + 16);
+    CHEQ(rd32(off + 0), 0u);
+    CHEQ(rd32(off + 4), 0u);
+    /* Entry 1 covers the text, and sh_info says it is the first global. */
+    CHEQ(rd32(shdr(y) + 28), 1u);
+    CHEQ(rd32(off + 16 + 4), RV_ELF_LOAD_ADDR);
+    CHEQ(rd32(off + 16 + 8), 12u);
+    CHEQ(rd[off + 16 + 12], 0x12u);              /* STB_GLOBAL | STT_FUNC */
+    CHEQ(rd16(off + 16 + 14), sfind(".text"));
+    PASS();
+}
+TH_REG("rv_enc", rv_elf_symtab);
+
+/* ReadImage:520 -- every SHF_ALLOC section must fall inside a segment. */
+static void rv_elf_alloc_in_seg(void)
+{
+    build_kernel();
+    rv_elf_write(&B, ELF_OUT);
+    slurp(ELF_OUT);
+    uint32_t ph = rd32(28);
+    uint32_t lo = rd32(ph + 8);
+    uint32_t hi = lo + rd32(ph + 20);
+    uint32_t nsec = rd16(48);
+    for (uint32_t i = 1; i < nsec; i++) {
+        if (!(rd32(shdr(i) + 8) & 2u)) continue;
+        uint32_t a = rd32(shdr(i) + 12);
+        CHECK(a >= lo && a + rd32(shdr(i) + 20) <= hi);
+    }
+    PASS();
+}
+TH_REG("rv_enc", rv_elf_alloc_in_seg);
+
+/*
+ * Structural invariants. The field-by-field tests above check that each
+ * value is what we meant; these check the layout is self-consistent, which
+ * is what actually breaks when the planner and the writer disagree.
+ */
+
+/* Every section body lies inside the file. SHT_NULL and SHT_NOBITS occupy
+ * no file space and are exempt. */
+static void rv_elf_sections_in_file(void)
+{
+    build_kernel();
+    rv_elf_write(&B, ELF_OUT);
+    long n = slurp(ELF_OUT);
+    uint32_t nsec = rd16(48);
+    for (uint32_t i = 1; i < nsec; i++) {
+        if (rd32(shdr(i) + 4) == 0u || rd32(shdr(i) + 4) == 8u) continue;
+        uint32_t off = rd32(shdr(i) + 16);
+        uint32_t sz  = rd32(shdr(i) + 20);
+        CHECK((long)(off + sz) <= n);
+    }
+    PASS();
+}
+TH_REG("rv_enc", rv_elf_sections_in_file);
+
+/* The section header table itself lies inside the file. */
+static void rv_elf_shdrs_in_file(void)
+{
+    build_kernel();
+    rv_elf_write(&B, ELF_OUT);
+    long n = slurp(ELF_OUT);
+    CHECK((long)(rd32(32) + rd16(48) * 40u) <= n);
+    PASS();
+}
+TH_REG("rv_enc", rv_elf_shdrs_in_file);
+
+/* No two non-empty section bodies overlap on disk. A planner that
+ * miscomputes one offset usually shows up here first. */
+static void rv_elf_no_overlap(void)
+{
+    build_kernel();
+    rv_elf_write(&B, ELF_OUT);
+    slurp(ELF_OUT);
+    uint32_t nsec = rd16(48);
+    for (uint32_t i = 1; i < nsec; i++) {
+        uint32_t ao = rd32(shdr(i) + 16), az = rd32(shdr(i) + 20);
+        if (az == 0u || rd32(shdr(i) + 4) == 8u) continue;
+        for (uint32_t j = i + 1u; j < nsec; j++) {
+            uint32_t bo = rd32(shdr(j) + 16), bz = rd32(shdr(j) + 20);
+            if (bz == 0u || rd32(shdr(j) + 4) == 8u) continue;
+            CHECK(ao + az <= bo || bo + bz <= ao);
+        }
+    }
+    PASS();
+}
+TH_REG("rv_enc", rv_elf_no_overlap);
+
+/* ReadImage:509 -- alloc, rela and symtab sections need sh_offset and
+ * sh_addr 4-byte aligned. */
+static void rv_elf_section_align(void)
+{
+    build_kernel();
+    rv_elf_write(&B, ELF_OUT);
+    slurp(ELF_OUT);
+    uint32_t nsec = rd16(48);
+    for (uint32_t i = 1; i < nsec; i++) {
+        uint32_t ty = rd32(shdr(i) + 4);
+        int needs = (rd32(shdr(i) + 8) & 2u) || ty == 4u || ty == 2u;
+        if (!needs) continue;
+        CHEQ((rd32(shdr(i) + 16) | rd32(shdr(i) + 12)) & 3u, 0u);
+    }
+    PASS();
+}
+TH_REG("rv_enc", rv_elf_section_align);
+
+/* Every section name resolves inside .shstrtab and is NUL-terminated. */
+static void rv_elf_names_resolve(void)
+{
+    build_kernel();
+    rv_elf_write(&B, ELF_OUT);
+    slurp(ELF_OUT);
+    uint32_t strsh = shdr(rd16(50));
+    uint32_t base = rd32(strsh + 16), size = rd32(strsh + 20);
+    CHEQ(rd[base + size - 1u], 0u);
+    uint32_t nsec = rd16(48);
+    for (uint32_t i = 0; i < nsec; i++) {
+        CHECK(rd32(shdr(i)) < size);
+    }
+    PASS();
+}
+TH_REG("rv_enc", rv_elf_names_resolve);
+
+/* .text's section header and its program header must describe the same
+ * bytes, since the loader validates coverage across the two. */
+static void rv_elf_text_matches_phdr(void)
+{
+    build_kernel();
+    rv_elf_write(&B, ELF_OUT);
+    slurp(ELF_OUT);
+    uint32_t t = sfind(".text"), ph = rd32(28);
+    CHEQ(rd32(shdr(t) + 12), rd32(ph + 8));      /* sh_addr  == p_vaddr  */
+    CHEQ(rd32(shdr(t) + 16), rd32(ph + 4));      /* sh_offset == p_offset */
+    CHEQ(rd32(shdr(t) + 20), rd32(ph + 16));     /* sh_size  == p_filesz */
+    PASS();
+}
+TH_REG("rv_enc", rv_elf_text_matches_phdr);
+
+/* The load address is named in three places and the loader checks each
+ * against a different thing, so they have to agree. TrimSegments runs
+ * during ReadImage and matches the link-time address, before XIPify
+ * rezeros it. */
+static void rv_elf_load_addr_agrees(void)
+{
+    build_kernel();
+    rv_elf_write(&B, ELF_OUT);
+    slurp(ELF_OUT);
+    uint32_t segs = rd32(shdr(sfind(".segments")) + 16);
+    CHEQ(rd32(24), rd32(rd32(28) + 8));          /* e_entry == p_vaddr */
+    CHEQ(rd32(24), rd32(segs));                  /* e_entry == segments vma */
+    PASS();
+}
+TH_REG("rv_enc", rv_elf_load_addr_agrees);
+
+/* .symtab size must be a whole number of entries, and sh_info must name a
+ * real one. */
+static void rv_elf_symtab_wellformed(void)
+{
+    build_kernel();
+    rv_elf_write(&B, ELF_OUT);
+    slurp(ELF_OUT);
+    uint32_t y = sfind(".symtab");
+    uint32_t sz = rd32(shdr(y) + 20), es = rd32(shdr(y) + 36);
+    CHECK(es != 0u);
+    CHEQ(sz % es, 0u);
+    CHECK(rd32(shdr(y) + 28) <= sz / es);
+    PASS();
+}
+TH_REG("rv_enc", rv_elf_symtab_wellformed);
+
+/* A one-instruction kernel still has to satisfy every alignment rule; the
+ * smallest input is where padding bugs hide. */
+static void rv_elf_minimal_kernel(void)
+{
+    rv_buf_init(&B);
+    rv_buf_emit(&B, rv_nop());
+    CHEQ(rv_elf_write(&B, ELF_OUT), BC_OK);
+    long n = slurp(ELF_OUT);
+    uint32_t ph = rd32(28);
+    CHEQ(rd32(ph + 16), 4u);
+    CHEQ((rd32(ph + 4) | rd32(ph + 8) | rd32(ph + 12)) & 3u, 0u);
+    CHECK((long)(rd32(32) + rd16(48) * 40u) <= n);
+    PASS();
+}
+TH_REG("rv_enc", rv_elf_minimal_kernel);
+
+/* Text size tracks the buffer rather than a fixed guess. */
+static void rv_elf_size_tracks_code(void)
+{
+    rv_buf_init(&B);
+    for (int i = 0; i < 64; i++) rv_buf_emit(&B, rv_nop());
+    CHEQ(rv_elf_write(&B, ELF_OUT), BC_OK);
+    slurp(ELF_OUT);
+    CHEQ(rd32(rd32(28) + 16), 256u);
+    CHEQ(rd32(shdr(sfind(".text")) + 20), 256u);
+    PASS();
+}
+TH_REG("rv_enc", rv_elf_size_tracks_code);
+
+/*
+ * End-to-end: drive the real compiler binary over a real .cu and validate
+ * what lands on disk. Everything above builds its input by hand, so none of
+ * it covers main.c's wiring, which is where the worst bug in this backend
+ * lived. Compiling in-process would not have caught it either.
+ */
+
+/* system() goes through cmd.exe on Windows, which does not search the cwd,
+ * so the path has to be explicit and backslashed. */
+#ifdef _WIN32
+#define KATH ".\\kath"
+#define QUIET "2>nul"
+#else
+#define KATH "./kath"
+#define QUIET "2>/dev/null"
+#endif
+
+#define E2E_OUT "e2e_rv.elf"
+
+/* Compile a fixture with --rv-elf. Returns the binary's exit status. */
+static int compile_cu(const char *cu)
+{
+    char cmd[512];
+    snprintf(cmd, sizeof(cmd), "%s --rv-elf -o %s tests/%s %s",
+             KATH, E2E_OUT, cu, QUIET);
+    return system(cmd);
+}
+
+/* File offset and word count of .text in the slurped image. */
+static void text_span(uint32_t *off, uint32_t *nwords)
+{
+    uint32_t t = sfind(".text");
+    *off = rd32(shdr(t) + 16);
+    *nwords = rd32(shdr(t) + 20) / 4u;
+}
+
+/* A kernel with __device__ helpers compiles, and the result satisfies the
+ * same loader contract the synthetic tests check. */
+static void e2e_rv_device_calls(void)
+{
+    CHEQ(compile_cu("device_calls.cu"), 0);
+    long n = slurp(E2E_OUT);
+    CHECK(n > 52);
+    CHEQ(rd[0], 0x7Fu);
+    CHEQ(rd16(18), 243u);                        /* EM_RISCV */
+    CHECK(sfind(".segments") != 0xFFFFFFFFu);
+    CHECK(sfind(".rela.text") != 0xFFFFFFFFu);
+    CHECK(sfind(".symtab") != 0xFFFFFFFFu);
+    CHEQ(rd32(24), rd32(rd32(28) + 8));          /* e_entry == p_vaddr */
+    PASS();
+}
+TH_REG("rv_enc", e2e_rv_device_calls);
+
+/* An unpatched call placeholder is a zero word, which is an illegal RV32
+ * instruction. main.c used to call rv_isel_func, which records call
+ * patches but never resolves them. */
+static void e2e_rv_calls_patched(void)
+{
+    CHEQ(compile_cu("device_calls.cu"), 0);
+    slurp(E2E_OUT);
+    uint32_t off, nw;
+    text_span(&off, &nw);
+    CHECK(nw > 0);
+    int jal = 0;
+    for (uint32_t i = 0; i < nw; i++) {
+        uint32_t w = rd32(off + i * 4u);
+        CHECK(w != 0u);
+        if ((w & 0x7Fu) == 0x6Fu) jal++;
+    }
+    CHECK(jal > 0);
+    PASS();
+}
+TH_REG("rv_enc", e2e_rv_calls_patched);
+
+/*
+ * The entry point must be the __global__ kernel. Source order puts the
+ * __device__ helpers first, so emitting functions in index order made the
+ * ELF enter sq() instead of the kernel: a valid ELF running the wrong
+ * program, with no diagnostic.
+ *
+ * device_calls.cu's kernel calls helpers and every helper is a leaf, so
+ * "the first function contains a JAL" distinguishes them.
+ */
+static void e2e_rv_kernel_is_entry(void)
+{
+    CHEQ(compile_cu("device_calls.cu"), 0);
+    slurp(E2E_OUT);
+    uint32_t off, nw;
+    text_span(&off, &nw);
+    int jal = 0;
+    uint32_t i = 0;
+    for (; i < nw; i++) {
+        uint32_t w = rd32(off + i * 4u);
+        if ((w & 0x7Fu) == 0x6Fu) jal++;
+        if (w == 0x00008067u) break;             /* jalr zero, ra, 0 */
+    }
+    CHECK(i < nw);                               /* entry function returns */
+    CHECK(jal > 0);                              /* and it is not a leaf */
+    PASS();
+}
+TH_REG("rv_enc", e2e_rv_kernel_is_entry);
+
+/* Text is a whole number of 4-byte instructions and fits a baby core. */
+static void e2e_rv_text_sane(void)
+{
+    CHEQ(compile_cu("device_calls.cu"), 0);
+    slurp(E2E_OUT);
+    uint32_t t = sfind(".text");
+    uint32_t sz = rd32(shdr(t) + 20);
+    CHEQ(sz % 4u, 0u);
+    CHECK(sz > 0u && sz <= RV_ELF_TEXT_LIMIT);
+    PASS();
+}
+TH_REG("rv_enc", e2e_rv_text_sane);
+
+/* Switch lowers to a compare chain, one BEQ per case, falling through to an
+ * unconditional jump to the default block. */
+static void e2e_rv_switch_chain(void)
+{
+    CHEQ(compile_cu("rv_switch.cu"), 0);
+    slurp(E2E_OUT);
+    uint32_t off, nw;
+    text_span(&off, &nw);
+    int beq = 0, jal = 0;
+    for (uint32_t i = 0; i < nw; i++) {
+        uint32_t w = rd32(off + i * 4u);
+        CHECK(w != 0u);
+        if ((w & 0x7Fu) == 0x63u && ((w >> 12) & 7u) == 0u) beq++;
+        if ((w & 0x7Fu) == 0x6Fu) jal++;
+    }
+    CHEQ(beq, 3);
+    CHECK(jal > 0);
+    PASS();
+}
+TH_REG("rv_enc", e2e_rv_switch_chain);
+
+/* __shared__ resolves to an absolute address in the L1 slab at the top of
+ * memory, materialised with a LUI whose upper immediate is the slab base. */
+static void e2e_rv_shared_addr(void)
+{
+    CHEQ(compile_cu("rv_shared.cu"), 0);
+    slurp(E2E_OUT);
+    uint32_t off, nw;
+    text_span(&off, &nw);
+    int found = 0;
+    for (uint32_t i = 0; i < nw; i++) {
+        uint32_t w = rd32(off + i * 4u);
+        if ((w & 0x7Fu) == 0x37u && ((w >> 12) << 12) == TD_L1_SHARED_BASE)
+            found = 1;
+    }
+    CHECK(found);
+    PASS();
+}
+TH_REG("rv_enc", e2e_rv_shared_addr);
+
+/* The shared slab and the circular buffers must not overlap, which is only
+ * true while the placer's ceiling is the slab base. */
+static void rv_l1_shared_below_end(void)
+{
+    CHECK(TD_L1_SHARED_BASE + TD_L1_SHARED_SIZE == TD_L1_END);
+    CHECK(TD_L1_CB_BASE < TD_L1_SHARED_BASE);
+    PASS();
+}
+TH_REG("rv_enc", rv_l1_shared_below_end);

--- a/tests/trv_isel.c
+++ b/tests/trv_isel.c
@@ -320,16 +320,29 @@ static void rv_isel_param_via_l1(void)
 }
 TH_REG("rv_enc", rv_isel_param_via_l1);
 
-static void rv_isel_refuses_barrier(void)
+/* A baby core is a single hardware thread with no SIMT, so __syncthreads()
+ * has nothing to wait on and lowers to nothing. FENCE would be wrong to
+ * emit: it is a documented no-op on this core and cannot order anything,
+ * so it would only suggest a guarantee we are not making. */
+static void rv_isel_barrier_is_noop(void)
 {
+    build_bir_add();
+    rv_buf_init(&code);
+    CHEQ(rv_isel_func(&fake_bir, 0, &code), BC_OK);
+    uint32_t base = rv_buf_n_words(&code);
+
     build_bir_add();
     fake_bir.insts[3].op = BIR_BARRIER;
     fake_bir.insts[3].num_operands = 0;
     rv_buf_init(&code);
-    CHEQ(rv_isel_func(&fake_bir, 0, &code), BC_ERR_TDF);
+    CHEQ(rv_isel_func(&fake_bir, 0, &code), BC_OK);
+    /* Swapping an instruction for a barrier can only shrink the output,
+     * and the barrier itself must contribute nothing. */
+    CHECK(rv_buf_n_words(&code) <= base);
+    CHECK(!buf_contains(rv_fence(0xFu, 0xFu)));
     PASS();
 }
-TH_REG("rv_enc", rv_isel_refuses_barrier);
+TH_REG("rv_enc", rv_isel_barrier_is_noop);
 
 /* ---- Helper: build a minimal "binop kernel" template ----
  *
@@ -1451,3 +1464,341 @@ static void rv_isel_alloca_offset(void)
     PASS();
 }
 TH_REG("rv_enc", rv_isel_alloca_offset);
+
+/*
+ * Regressions for the four silent miscompiles found in the July 2026
+ * audit. Each one produced a valid-looking ELF that traps or corrupts
+ * memory on the core, so they get tests before anything else lands.
+ */
+
+/* Decode an sp-relative LW/SW offset, or return -1 if the word is neither. */
+static int sp_slot_off(uint32_t w)
+{
+    uint32_t rs1 = (w >> 15) & 0x1Fu;
+    uint32_t f3  = (w >> 12) & 0x7u;
+    if (rs1 != RV_SP || f3 != 2u) return -1;
+    if ((w & 0x7Fu) == 0x03u) return (int)((w >> 20) & 0xFFFu);      /* LW */
+    if ((w & 0x7Fu) == 0x23u) {                                       /* SW */
+        return (int)((((w >> 25) & 0x7Fu) << 5) | ((w >> 7) & 0x1Fu));
+    }
+    return -1;
+}
+
+/* Slot indices used to be module-global while the frame was sized from
+ * the function's own instruction count, so function 1 addressed past its
+ * frame and into the caller's. Every slot must sit inside the largest
+ * frame this module allocates, which is 32 bytes here. */
+static void rv_isel_slots_are_frame_local(void)
+{
+    build_bir_kern_calls_helper();
+    rv_buf_init(&code);
+    CHEQ(rv_isel_module(&fake_bir, &code), BC_OK);
+
+    for (uint32_t i = 0; i < rv_buf_n_words(&code); i++) {
+        int off = sp_slot_off(rv_buf_data(&code)[i]);
+        CHECK(off < 32);
+    }
+    PASS();
+}
+TH_REG("rv_enc", rv_isel_slots_are_frame_local);
+
+/* Past roughly 510 instructions the slot offset overflowed the 12-bit
+ * signed immediate and wrapped negative, reading below the frame. It has
+ * to refuse instead. */
+static void rv_isel_refuses_huge_frame(void)
+{
+    memset(&fake_bir, 0, sizeof(fake_bir));
+    fake_bir.num_types = 2;
+    fake_bir.types[0].kind = BIR_TYPE_INT;
+    fake_bir.types[0].width = 32;
+    fake_bir.types[1].kind = BIR_TYPE_VOID;
+
+    const uint32_t n = 600;
+    fake_bir.num_funcs = 1;
+    fake_bir.num_blocks = 1;
+    fake_bir.num_insts = n;
+    fake_bir.funcs[0].first_block = 0;
+    fake_bir.funcs[0].num_blocks = 1;
+    fake_bir.funcs[0].total_insts = n;
+    fake_bir.funcs[0].cuda_flags = CUDA_GLOBAL;
+    fake_bir.blocks[0].first_inst = 0;
+    fake_bir.blocks[0].num_insts = n;
+    for (uint32_t i = 0; i < n - 1u; i++) {
+        fake_bir.insts[i].op = BIR_PARAM;
+        fake_bir.insts[i].subop = 0;
+        fake_bir.insts[i].type = 0;
+    }
+    fake_bir.insts[n - 1u].op = BIR_RET;
+    fake_bir.insts[n - 1u].type = 1;
+    fake_bir.insts[n - 1u].num_operands = 0;
+
+    rv_buf_init(&code);
+    CHEQ(rv_isel_func(&fake_bir, 0, &code), BC_ERR_TDF);
+    PASS();
+}
+TH_REG("rv_enc", rv_isel_refuses_huge_frame);
+
+/* Build a kernel storing through a pointer whose pointee is `w` bits
+ * wide, then loading it back: PARAM ptr, LOAD, STORE, RET. */
+static void build_bir_narrow(uint16_t w)
+{
+    memset(&fake_bir, 0, sizeof(fake_bir));
+    fake_bir.num_types = 3;
+    fake_bir.types[0].kind = BIR_TYPE_INT;
+    fake_bir.types[0].width = w;
+    fake_bir.types[1].kind = BIR_TYPE_PTR;
+    fake_bir.types[1].addrspace = BIR_AS_GLOBAL;
+    fake_bir.types[1].inner = 0;
+    fake_bir.types[2].kind = BIR_TYPE_VOID;
+
+    fake_bir.num_funcs = 1;
+    fake_bir.num_blocks = 1;
+    fake_bir.num_insts = 4;
+    fake_bir.funcs[0].first_block = 0;
+    fake_bir.funcs[0].num_blocks = 1;
+    fake_bir.funcs[0].num_params = 1;
+    fake_bir.funcs[0].total_insts = 4;
+    fake_bir.funcs[0].cuda_flags = CUDA_GLOBAL;
+    fake_bir.blocks[0].first_inst = 0;
+    fake_bir.blocks[0].num_insts = 4;
+
+    fake_bir.insts[0].op = BIR_PARAM;
+    fake_bir.insts[0].subop = 0;
+    fake_bir.insts[0].type = 1;
+    fake_bir.insts[1].op = BIR_LOAD;
+    fake_bir.insts[1].type = 0;
+    fake_bir.insts[1].num_operands = 1;
+    fake_bir.insts[1].operands[0] = BIR_MAKE_VAL(0);
+    fake_bir.insts[2].op = BIR_STORE;
+    fake_bir.insts[2].type = 2;
+    fake_bir.insts[2].num_operands = 2;
+    fake_bir.insts[2].operands[0] = BIR_MAKE_VAL(1);
+    fake_bir.insts[2].operands[1] = BIR_MAKE_VAL(0);
+    fake_bir.insts[3].op = BIR_RET;
+    fake_bir.insts[3].type = 2;
+    fake_bir.insts[3].num_operands = 0;
+}
+
+/* Sub-word accesses used to emit LW/SW regardless of pointee width, so a
+ * char store clobbered the three neighbouring bytes. */
+static void rv_isel_byte_access(void)
+{
+    build_bir_narrow(8);
+    rv_buf_init(&code);
+    CHEQ(rv_isel_func(&fake_bir, 0, &code), BC_OK);
+    CHECK(buf_contains(rv_lbu(RV_T0, RV_T1, 0)));
+    CHECK(buf_contains(rv_sb(RV_T0, RV_T1, 0)));
+    CHECK(!buf_contains(rv_lw(RV_T0, RV_T1, 0)));
+    CHECK(!buf_contains(rv_sw(RV_T0, RV_T1, 0)));
+    PASS();
+}
+TH_REG("rv_enc", rv_isel_byte_access);
+
+static void rv_isel_half_access(void)
+{
+    build_bir_narrow(16);
+    rv_buf_init(&code);
+    CHEQ(rv_isel_func(&fake_bir, 0, &code), BC_OK);
+    CHECK(buf_contains(rv_lhu(RV_T0, RV_T1, 0)));
+    CHECK(buf_contains(rv_sh(RV_T0, RV_T1, 0)));
+    PASS();
+}
+TH_REG("rv_enc", rv_isel_half_access);
+
+static void rv_isel_word_access_unchanged(void)
+{
+    build_bir_narrow(32);
+    rv_buf_init(&code);
+    CHEQ(rv_isel_func(&fake_bir, 0, &code), BC_OK);
+    CHECK(buf_contains(rv_lw(RV_T0, RV_T1, 0)));
+    CHECK(buf_contains(rv_sw(RV_T0, RV_T1, 0)));
+    PASS();
+}
+TH_REG("rv_enc", rv_isel_word_access_unchanged);
+
+/* tt-metal reads a0 as the stack watermark, where zero means "not
+ * computed". A void return used to leave it holding whatever was there. */
+static void rv_isel_void_ret_zeroes_a0(void)
+{
+    build_bir_narrow(32);
+    rv_buf_init(&code);
+    CHEQ(rv_isel_func(&fake_bir, 0, &code), BC_OK);
+    CHECK(buf_contains(rv_addi(RV_A0, RV_ZERO, 0)));
+    PASS();
+}
+TH_REG("rv_enc", rv_isel_void_ret_zeroes_a0);
+
+/* Build two functions where the second one allocas, so the alloca table is
+ * indexed by a nonzero module-global instruction index. */
+static void build_bir_helper_allocas(void)
+{
+    memset(&fake_bir, 0, sizeof(fake_bir));
+    fake_bir.num_types = 3;
+    fake_bir.types[0].kind = BIR_TYPE_INT;
+    fake_bir.types[0].width = 32;
+    fake_bir.types[1].kind = BIR_TYPE_PTR;
+    fake_bir.types[1].addrspace = BIR_AS_PRIVATE;
+    fake_bir.types[1].inner = 0;
+    fake_bir.types[2].kind = BIR_TYPE_VOID;
+
+    fake_bir.num_funcs = 2;
+    fake_bir.num_blocks = 2;
+    fake_bir.num_insts = 5;
+
+    /* Function 0: PARAM, RET void. */
+    fake_bir.funcs[0].first_block = 0;
+    fake_bir.funcs[0].num_blocks = 1;
+    fake_bir.funcs[0].num_params = 1;
+    fake_bir.funcs[0].total_insts = 2;
+    fake_bir.funcs[0].cuda_flags = CUDA_GLOBAL;
+    fake_bir.blocks[0].first_inst = 0;
+    fake_bir.blocks[0].num_insts = 2;
+    fake_bir.insts[0].op = BIR_PARAM;
+    fake_bir.insts[0].subop = 0;
+    fake_bir.insts[0].type = 0;
+    fake_bir.insts[1].op = BIR_RET;
+    fake_bir.insts[1].type = 2;
+    fake_bir.insts[1].num_operands = 0;
+
+    /* Function 1: ALLOCA, ALLOCA, RET void. Instructions 2..4. */
+    fake_bir.funcs[1].first_block = 1;
+    fake_bir.funcs[1].num_blocks = 1;
+    fake_bir.funcs[1].total_insts = 3;
+    fake_bir.funcs[1].cuda_flags = 0;
+    fake_bir.blocks[1].first_inst = 2;
+    fake_bir.blocks[1].num_insts = 3;
+    fake_bir.insts[2].op = BIR_ALLOCA;
+    fake_bir.insts[2].type = 1;
+    fake_bir.insts[3].op = BIR_ALLOCA;
+    fake_bir.insts[3].type = 1;
+    fake_bir.insts[4].op = BIR_RET;
+    fake_bir.insts[4].type = 2;
+    fake_bir.insts[4].num_operands = 0;
+}
+
+/* The alloca table was indexed by the module-global instruction index while
+ * the region was sized per function, so a second function's allocas landed
+ * outside its own frame. Function 1's frame is 8 + 3*4 + 8 = 28, rounded to
+ * 32, with its allocas at 20 and 24. */
+static void rv_isel_alloca_in_second_func(void)
+{
+    build_bir_helper_allocas();
+    rv_buf_init(&code);
+    CHEQ(rv_isel_module(&fake_bir, &code), BC_OK);
+    CHECK(buf_contains(rv_addi(RV_T0, RV_SP, 20)));
+    CHECK(buf_contains(rv_addi(RV_T0, RV_SP, 24)));
+    PASS();
+}
+TH_REG("rv_enc", rv_isel_alloca_in_second_func);
+
+/* An unpatched call placeholder is a zero word, which is an illegal RV32
+ * instruction that traps with no diagnostic. Nothing the module path emits
+ * should ever be zero. */
+static void rv_isel_no_illegal_words(void)
+{
+    build_bir_kern_calls_helper();
+    rv_buf_init(&code);
+    CHEQ(rv_isel_module(&fake_bir, &code), BC_OK);
+    CHECK(rv_buf_n_words(&code) > 0);
+    CHECK(!buf_contains(0u));
+    PASS();
+}
+TH_REG("rv_enc", rv_isel_no_illegal_words);
+
+/* An i64 access has no single RV32 instruction. It used to compile to LW and
+ * silently move four of the eight bytes. */
+static void rv_isel_refuses_i64_access(void)
+{
+    build_bir_narrow(64);
+    rv_buf_init(&code);
+    CHEQ(rv_isel_func(&fake_bir, 0, &code), BC_ERR_TDF);
+    PASS();
+}
+TH_REG("rv_enc", rv_isel_refuses_i64_access);
+
+/* Same for an aggregate pointee. */
+static void rv_isel_refuses_struct_access(void)
+{
+    build_bir_narrow(32);
+    /* Repoint the pointer at a two-field struct instead of a bare i32. */
+    fake_bir.num_types = 4;
+    fake_bir.types[3].kind = BIR_TYPE_STRUCT;
+    fake_bir.types[3].num_fields = 2;
+    fake_bir.types[3].count = 0;
+    fake_bir.num_type_fields = 2;
+    fake_bir.type_fields[0] = 0;
+    fake_bir.type_fields[1] = 0;
+    fake_bir.types[1].inner = 3;
+
+    rv_buf_init(&code);
+    CHEQ(rv_isel_func(&fake_bir, 0, &code), BC_ERR_TDF);
+    PASS();
+}
+TH_REG("rv_enc", rv_isel_refuses_struct_access);
+
+/* Build a single function of n instructions: n-1 PARAMs then a void RET. */
+static void build_bir_n_insts(uint32_t n)
+{
+    memset(&fake_bir, 0, sizeof(fake_bir));
+    fake_bir.num_types = 2;
+    fake_bir.types[0].kind = BIR_TYPE_INT;
+    fake_bir.types[0].width = 32;
+    fake_bir.types[1].kind = BIR_TYPE_VOID;
+    fake_bir.num_funcs = 1;
+    fake_bir.num_blocks = 1;
+    fake_bir.num_insts = n;
+    fake_bir.funcs[0].first_block = 0;
+    fake_bir.funcs[0].num_blocks = 1;
+    fake_bir.funcs[0].total_insts = n;
+    fake_bir.funcs[0].cuda_flags = CUDA_GLOBAL;
+    fake_bir.blocks[0].first_inst = 0;
+    fake_bir.blocks[0].num_insts = n;
+    for (uint32_t i = 0; i < n - 1u; i++) {
+        fake_bir.insts[i].op = BIR_PARAM;
+        fake_bir.insts[i].subop = 0;
+        fake_bir.insts[i].type = 0;
+    }
+    fake_bir.insts[n - 1u].op = BIR_RET;
+    fake_bir.insts[n - 1u].type = 1;
+    fake_bir.insts[n - 1u].num_operands = 0;
+}
+
+/* The frame is 8 + 4n rounded to 16, and the prologue adjusts sp with one
+ * ADDI, so 2032 bytes is the last frame that fits the 12-bit immediate.
+ * That puts the boundary at 506 instructions. */
+static void rv_isel_frame_boundary_ok(void)
+{
+    build_bir_n_insts(506);
+    rv_buf_init(&code);
+    CHEQ(rv_isel_func(&fake_bir, 0, &code), BC_OK);
+    CHECK(buf_contains(rv_addi(RV_SP, RV_SP, -2032)));
+    CHECK(buf_contains(rv_addi(RV_SP, RV_SP, 2032)));
+    PASS();
+}
+TH_REG("rv_enc", rv_isel_frame_boundary_ok);
+
+static void rv_isel_frame_boundary_refused(void)
+{
+    build_bir_n_insts(507);
+    rv_buf_init(&code);
+    CHEQ(rv_isel_func(&fake_bir, 0, &code), BC_ERR_TDF);
+    PASS();
+}
+TH_REG("rv_enc", rv_isel_frame_boundary_refused);
+
+/* Every slot access in the largest accepted function stays inside the frame
+ * and within the positive half of the 12-bit immediate. */
+static void rv_isel_max_frame_slots_in_range(void)
+{
+    build_bir_n_insts(506);
+    rv_buf_init(&code);
+    CHEQ(rv_isel_func(&fake_bir, 0, &code), BC_OK);
+    for (uint32_t i = 0; i < rv_buf_n_words(&code); i++) {
+        int off = sp_slot_off(rv_buf_data(&code)[i]);
+        if (off < 0) continue;
+        CHECK(off <= 2047);
+        CHECK(off < 2032);
+    }
+    PASS();
+}
+TH_REG("rv_enc", rv_isel_max_frame_slots_in_range);

--- a/tests/trv_isel.c
+++ b/tests/trv_isel.c
@@ -1802,3 +1802,44 @@ static void rv_isel_max_frame_slots_in_range(void)
     PASS();
 }
 TH_REG("rv_enc", rv_isel_max_frame_slots_in_range);
+
+/* i64 has no RV32 representation. This used to compile, with the mul becoming
+ * 32-bit and the shift by 32 becoming a shift by zero. No diagnostic. */
+static void rv_isel_refuses_i64_arith(void)
+{
+    memset(&fake_bir, 0, sizeof(fake_bir));
+    fake_bir.num_types = 3;
+    fake_bir.types[0].kind = BIR_TYPE_INT;
+    fake_bir.types[0].width = 32;
+    fake_bir.types[1].kind = BIR_TYPE_INT;
+    fake_bir.types[1].width = 64;
+    fake_bir.types[2].kind = BIR_TYPE_VOID;
+
+    fake_bir.num_funcs = 1;
+    fake_bir.num_blocks = 1;
+    fake_bir.num_insts = 3;
+    fake_bir.funcs[0].first_block = 0;
+    fake_bir.funcs[0].num_blocks = 1;
+    fake_bir.funcs[0].num_params = 1;
+    fake_bir.funcs[0].total_insts = 3;
+    fake_bir.funcs[0].cuda_flags = CUDA_GLOBAL;
+    fake_bir.blocks[0].first_inst = 0;
+    fake_bir.blocks[0].num_insts = 3;
+
+    fake_bir.insts[0].op = BIR_PARAM;
+    fake_bir.insts[0].subop = 0;
+    fake_bir.insts[0].type = 0;
+    /* zext i32 -> i64: the i64 result is what must be refused. */
+    fake_bir.insts[1].op = BIR_ZEXT;
+    fake_bir.insts[1].type = 1;
+    fake_bir.insts[1].num_operands = 1;
+    fake_bir.insts[1].operands[0] = BIR_MAKE_VAL(0);
+    fake_bir.insts[2].op = BIR_RET;
+    fake_bir.insts[2].type = 2;
+    fake_bir.insts[2].num_operands = 0;
+
+    rv_buf_init(&code);
+    CHEQ(rv_isel_func(&fake_bir, 0, &code), BC_ERR_TDF);
+    PASS();
+}
+TH_REG("rv_enc", rv_isel_refuses_i64_arith);

--- a/tests/ttdf.c
+++ b/tests/ttdf.c
@@ -791,3 +791,56 @@ static void tdf_writer_loop_shape(void)
     PASS();
 }
 TH_REG("tdf", tdf_writer_loop_shape);
+
+/*
+ * The --tdf and --tdf-fission flags have to appear in every one of main.c's
+ * four mode lists. They were missing from all of them, so the "no mode
+ * selected" fallback set mode_parse and the flags silently dumped an AST
+ * instead of running the pass. Only driving the binary catches this.
+ */
+
+#ifdef _WIN32
+#define TDF_KATH ".\\kath"
+#else
+#define TDF_KATH "./kath"
+#endif
+#define TDF_OUT "tdf_flag_out.txt"
+
+/* Run kath with the given flag over a fixture, return its stdout. */
+static const char *run_flag(const char *flag)
+{
+    static char buf[TH_BUFSZ];
+    char cmd[512];
+    snprintf(cmd, sizeof(cmd), "%s %s tests/rv_shared.cu > %s 2>&1",
+             TDF_KATH, flag, TDF_OUT);
+    buf[0] = '\0';
+    if (system(cmd) != 0) return buf;
+    FILE *fp = fopen(TDF_OUT, "rb");
+    if (!fp) return buf;
+    size_t n = fread(buf, 1, sizeof(buf) - 1, fp);
+    buf[n] = '\0';
+    fclose(fp);
+    return buf;
+}
+
+static void tdf_flag_reaches_pass(void)
+{
+    const char *o = run_flag("--tdf");
+    CHECK(strstr(o, "TDF module") != NULL);
+    CHECK(strstr(o, "translation_unit") == NULL);
+    PASS();
+}
+TH_REG("tdf", tdf_flag_reaches_pass);
+
+static void tdf_fission_flag_reaches_pass(void)
+{
+    const char *o = run_flag("--tdf-fission");
+    CHECK(strstr(o, "TDF module") != NULL);
+    CHECK(strstr(o, "translation_unit") == NULL);
+    /* Fission rewrites the graph into the three-region pipeline. */
+    CHECK(strstr(o, "RDR") != NULL);
+    CHECK(strstr(o, "CMP") != NULL);
+    CHECK(strstr(o, "WRT") != NULL);
+    PASS();
+}
+TH_REG("tdf", tdf_fission_flag_reaches_pass);


### PR DESCRIPTION
The RV32 path for the Tensix baby cores now compiles a .cu end to end into an ELF that tt-metal will actually load. Most of this branch is bug fixes that turned up on the way there.

The ELF writer was built from the public BabyRISCV README, which turns out to be wrong about what the loader wants. Reading tt_metal/llrt/tt_elffile.cpp instead: sections are mandatory, there has to be a .segments metadata section driving the trim and size checks, and XIPify throws outright if there is no relocation section. We emit no relocation entries because every branch and call is patched internally, but the empty .rela.text has to be there. e_entry, the first PT_LOAD's p_vaddr and the .segments vma all have to agree, and TrimSegments runs during ReadImage so it matches the link-time address rather than the rezeroed one.

Five things were silently miscompiling. main.c called rv_isel_func rather than rv_isel_module, so BIR_CALL placeholders were never patched and left illegal zero words, and worse, function 0 got emitted first, which for a kernel with __device__ helpers meant the ELF entry point ran a helper instead of the kernel. Stack slot indices were module-global while frames were sized per function, so anything past the first function addressed the caller's frame. Slot offsets past ~510 instructions wrapped the 12-bit immediate negative. i8 and i16 accesses were emitted as LW/SW, so a char store clobbered three neighbouring bytes. And i64 arithmetic compiled to 32-bit instructions, where a shift by 32 becomes a shift by zero because RV32 only reads shamt[4:0]; that one now refuses rather than lying.

Two frontend crashes, both affecting every backend rather than just Tensix. is_reg_type dereferenced anonymous struct name sentinels as if they were source offsets, which reads 2GB past the buffer and segfaults. And macro expansion ran per line without carrying block comment state, so a macro named in comment prose got substituted, and if its replacement contained a comment it closed the enclosing one early.

The Makefile had no header dependency tracking, so header edits left stale objects linked in and the build quietly disagreed with the source. That is fixed with -MMD, and it is worth knowing it was true for the whole history before this.

Also adds --tt-chip so the L1 map and text limits follow the target part rather than being implicitly Wormhole, defaulting to blackhole. SWITCH, UMULHI, shared memory and barriers now lower, taking the RV path to 42 of 76 BIR opcodes. Everything else refuses cleanly rather than guessing.

315 tests to 355. The new end-to-end ones drive the real binary over real .cu fixtures, which is what none of the previous 92 synthetic tests could do and why the entry-point bug survived this long.

Also adds two CI jobs, both verified locally under WSL Ubuntu rather than guessed at.

tt-metal's ELF reader builds standalone under -DELF_STANDALONE, stubbing out its own logging and needing nothing past elf.h and libstdc++. So CI can fetch those two files, build them, and feed our emitted kernels to Tenstorrent's actual loader rather than trusting my reading of it. All three RV32 fixtures are accepted. There is a negative step too, corrupting e_entry so it no longer matches the first PT_LOAD's p_vaddr, because a gate that cannot fail is theatre. It tracks tt-metal main rather than a pinned commit on purpose: if the loader contract changes, this is how we find out.

The second job compiles a kernel through --rv64, links it with gcc-riscv64-linux-gnu and runs it under qemu-riscv64, checking the arithmetic came out right. Both are plain apt packages. That takes the project from one backend checked by executing its output to three, alongside CPU via Moa and AMD via the tinygrad emulator.

Worth recording that the RV64 kernel ABI is not written down anywhere: declared parameters go in a0 onward, then a hidden trailing argument carries the thread count and the kernel loops over it internally. rv64_emit.c:363. That is why the host fixture takes an extra parameter.