### PR TITLE
amdgpu: stop a guard clause taking the whole wave down with it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ TSRC    = tests/tmain.c tests/tsmoke.c tests/tcomp.c tests/tenc.c \
           tests/twarpsize.c \
           tests/tabend.c \
           tests/tregalloc.c \
+          tests/tguard.c \
           tests/ttriton.c \
           tests/ttdf.c \
           tests/ttmc.c \

--- a/src/amdgpu/isel.c
+++ b/src/amdgpu/isel.c
@@ -1658,6 +1658,15 @@ static void isel_branch(const bir_inst_t *I)
     emit0_1(AMD_S_BRANCH, mop_label(target_mb));
 }
 
+/* A lone ret in a kernel — the guard clause every kernel opens with. */
+static int blk_is_kret(uint32_t bir_bi)
+{
+    if (!S.is_kernel || bir_bi >= S.bir->num_blocks) return 0;
+    const bir_block_t *B = &S.bir->blocks[bir_bi];
+    if (B->num_insts != 1) return 0;
+    return S.bir->insts[B->first_inst].op == BIR_RET;
+}
+
 static void isel_br_cond(const bir_inst_t *I, int cond_div)
 {
     uint32_t true_bir  = I->operands[1];
@@ -1665,6 +1674,21 @@ static void isel_br_cond(const bir_inst_t *I, int cond_div)
     if (true_bir >= BIR_MAX_BLOCKS || false_bir >= BIR_MAX_BLOCKS) return;
     uint32_t true_mb   = S.block_map[true_bir];
     uint32_t false_mb  = S.block_map[false_bir];
+
+    /* Masking down to the returning lanes and hitting s_endpgm kills the whole
+       wave — EXEC can't save them. andn2 benches just the returners, wave plays
+       on, and a ragged launch keeps the tail of its last wave. */
+    if (cond_div && blk_is_kret(true_bir)) {
+        moperand_t cond  = resolve_val(I->operands[0], 1);
+        moperand_t vcond = ensure_vgpr(cond);
+        emit0_2(AMD_V_CMP_NE_U32, mop_imm(0), vcond);   /* vcc = returning lanes */
+        emit2(S.mf->exec_w ? AMD_S_ANDN2_B64 : AMD_S_ANDN2_B32,
+              mop_special(AMD_SPEC_EXEC),
+              mop_special(AMD_SPEC_EXEC), mop_special(AMD_SPEC_VCC));
+        /* Lanes left run the body; an all-out wave falls through to s_endpgm. */
+        emit0_1(AMD_S_CBRANCH_EXECNZ, mop_label(false_mb));
+        return;
+    }
 
     if (cond_div) {
         /* Divergent branch: EXEC mask save/restore pattern.

--- a/tests/test_guard.cu
+++ b/tests/test_guard.cu
@@ -1,0 +1,9 @@
+/* test_guard.cu -- a divergent early-return guard, the opening line of most
+ * real kernels. It must lower to s_andn2 on EXEC, not s_and_saveexec then
+ * s_endpgm: the latter ends the whole wave and a ragged launch loses the
+ * in-range tail of its last wave. */
+extern "C" __global__ void guard(float *y, float *x, float a, int n) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= n) return;
+    y[i] = a * x[i] + y[i];
+}

--- a/tests/tguard.c
+++ b/tests/tguard.c
@@ -1,0 +1,26 @@
+/* tguard.c -- regression guard for the divergent early-return lowering.
+ * `if (i >= n) return;` must disable the returning lanes with s_andn2 and
+ * carry on; the old path masked EXEC down to them and hit s_endpgm, which
+ * ends the whole wave and drops a ragged launch's in-range tail. */
+#include "tharns.h"
+
+static char buf[1 << 16];
+
+static void guard_masks_not_ends(void)
+{
+    char cmd[TH_BUFSZ];
+    int rc;
+
+    snprintf(cmd, TH_BUFSZ, BC_BIN " --amdgpu tests/test_guard.cu");
+    rc = th_run(cmd, buf, (int)sizeof buf);
+    CHEQ(rc, 0);
+
+    /* The lanes that return are switched off with andn2 ... */
+    CHECK(strstr(buf, "s_andn2") != NULL);
+    /* ... and a lone guard needs no EXEC save/restore, so its absence is how
+       we know we are not back on the s_endpgm-under-mask path. */
+    CHECK(strstr(buf, "s_and_saveexec") == NULL);
+
+    PASS();
+}
+TH_REG("guard", guard_masks_not_ends)


### PR DESCRIPTION
`if (i >= n) return;` opens basically every kernel, and on AMD it was quietly taking the whole wavefront with it. s_endpgm ignores EXEC, so the moment one lane went out of range the wave ended, in-range neighbours and all. Any launch whose element count wasn't a multiple of the wave size dropped the tail of its last wave. Silently, exit 0.

Now it andn2's the returning lanes off EXEC and carries on, with a single endpgm at the end for whoever's left. Verified on emulated RDNA3/4 across ragged counts (200, 255), and there's a test that pins the lowering so it can't creep back in.