### PR TITLE
runtime: run LFortran do-concurrent on Booth, NVIDIA and AMD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,15 @@ ifeq ($(UNAME_S),Linux)
   DL_LIB  = -ldl
 endif
 
+# lf_gpu_hsa is the AMD sibling of lf_gpu: the same ABI over bc_runtime. It
+# defines the same symbols, so it can't sit in HOSTRT next to lf_gpu; we just
+# compile it (Linux only) to keep it under the strict flags. The Fortran build
+# links one runtime or the other depending on the target.
+ALT_RT =
+ifeq ($(UNAME_S),Linux)
+  ALT_RT = src/runtime/lf_gpu_hsa.o
+endif
+
 SOURCES = src/main.c \
           src/fe/bc_err.c src/fe/bc_render.c src/fe/preproc.c src/fe/lexer.c src/fe/parser.c src/fe/sema.c \
           src/ir/bir.c src/ir/bir_print.c src/ir/bir_lower.c src/ir/bir_mem2reg.c src/ir/bir_cfold.c src/ir/bir_dce.c src/ir/bir_struct.c src/ir/bir_insert.c src/ir/bir_sroa.c src/ir/bir_inline.c \
@@ -54,7 +63,7 @@ SOURCES = src/main.c \
 OBJECTS = $(SOURCES:.c=.o)
 TARGET  = kath
 
-all: $(TARGET)
+all: $(TARGET) $(ALT_RT)
 
 $(TARGET): $(OBJECTS)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LIBS)
@@ -120,7 +129,7 @@ runtime/%.o: runtime/%.c
 	$(CC) $(TCFLAGS) -c $< -o $@
 
 clean:
-	rm -f $(OBJECTS) $(TARGET) $(TARGET).exe trunner trunner.exe $(TOBJS) $(HOSTRT) src/runtime/*.o runtime/*.o
+	rm -f $(OBJECTS) $(TARGET) $(TARGET).exe trunner trunner.exe $(TOBJS) $(HOSTRT) $(ALT_RT) src/runtime/*.o runtime/*.o
 	rm -f $(OBJECTS:.o=.d) $(TOBJS:.o=.d) $(HOSTRT:.o=.d) src/runtime/*.d runtime/*.d
 
 # Header deps from -MMD. Without these a header edit leaves stale objects

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,12 @@ LIBS    = -lm
 # never into kath. nv_rt is portable (LoadLibraryA on Windows, dlopen elsewhere);
 # bc_runtime is Linux, bare dlfcn.h and libhsa. -ldl names Linux rather than
 # "not Windows" because macOS keeps dlopen in libSystem and ships no libdl.
+# lf_gpu implements LFortran's GPU offload ABI on top of nv_rt, so an
+# LFortran-compiled Fortran program can launch kernels kath produced. It
+# links into the Fortran executable, not into kath; it sits in HOSTRT so
+# the strict build keeps checking it.
 UNAME_S := $(shell uname -s 2>/dev/null)
-HOSTRT   = src/nvidia/nv_rt.o
+HOSTRT   = src/nvidia/nv_rt.o src/runtime/lf_gpu.o
 DL_LIB   =
 ifeq ($(UNAME_S),Linux)
   HOSTRT += src/runtime/bc_runtime.o

--- a/src/runtime/lf_gpu.c
+++ b/src/runtime/lf_gpu.c
@@ -1,0 +1,253 @@
+/* lf_gpu.c — LFortran GPU offload ABI over the Booth NVIDIA launcher.
+ *
+ * The ABI returns void and has no error channel, so a failure here is fatal
+ * and loud. Carrying on after a failed H2D copy would hand Fortran a result
+ * array full of whatever was in device memory, which is the one outcome
+ * worse than stopping.
+ *
+ * Kernels are PTX on disk, produced by kath from the .cu LFortran emits.
+ * The CUDA runtime gets its kernel from a static registrar linked into the
+ * host object; we have no such hook, so the path is resolved at load time.
+ */
+
+#include "lf_gpu.h"
+#include "nv_rt.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+/* ---- Limits ---- */
+
+#define LF_MAX_ARGS  32u    /* matches the isel parameter cap */
+#define LF_MAX_KERN   8u
+#define LF_SCAL_MAX  16u    /* widest scalar we pass by value */
+#define LF_PATH_MAX 512u
+
+/* ---- State ---- */
+
+/* One device, fixed kernel pool. A do-concurrent program launches a handful
+ * of kernels, so there is nothing here worth a malloc. */
+
+struct lfortran_gpu_ctx {
+    nv_dev_t dev;
+    int      live;
+};
+
+typedef struct {
+    void    *hptr;                    /* host side, for the copy back */
+    CUdevptr dptr;
+    size_t   size;
+    uint8_t  scal[LF_SCAL_MAX];
+    int      is_buf;
+    int      used;
+} lf_arg_t;
+
+struct lfortran_gpu_kernel {
+    nv_kern_t k;
+    lf_arg_t  args[LF_MAX_ARGS];
+    int       nargs;
+    int       used;
+    lfortran_gpu_ctx *ctx;
+};
+
+static lfortran_gpu_ctx    g_ctx;
+static lfortran_gpu_kernel g_kern[LF_MAX_KERN];
+
+/* ---- Helpers ---- */
+
+static void lf_die(const char *what, int rc)
+{
+    fprintf(stderr, "lf_gpu: %s failed (rc=%d)\n", what, rc);
+    exit(1);
+}
+
+/* Where to find the PTX. An explicit source string wins, then BOOTH_PTX for
+ * the case where the build put it somewhere odd, then the kernel name. */
+static void lf_ptx(const char *source, const char *entry,
+                   char *out, size_t cap)
+{
+    const char *env;
+
+    if (source != NULL && source[0] != '\0') {
+        (void)snprintf(out, cap, "%s", source);
+        return;
+    }
+    env = getenv("BOOTH_PTX");
+    if (env != NULL && env[0] != '\0') {
+        (void)snprintf(out, cap, "%s", env);
+        return;
+    }
+    (void)snprintf(out, cap, "%s.ptx", entry);
+}
+
+/* ---- Lifecycle ---- */
+
+lfortran_gpu_ctx *lfortran_gpu_init(void)
+{
+    int rc;
+
+    if (g_ctx.live) return &g_ctx;
+
+    rc = nv_rt_init(&g_ctx.dev);
+    if (rc != NV_RT_OK) lf_die("nv_rt_init", rc);
+
+    g_ctx.live = 1;
+    return &g_ctx;
+}
+
+void lfortran_gpu_shutdown(lfortran_gpu_ctx *ctx)
+{
+    uint32_t i;
+
+    if (ctx == NULL || !ctx->live) return;
+
+    for (i = 0u; i < LF_MAX_KERN; i++) {
+        if (g_kern[i].used) lfortran_gpu_release_kernel(&g_kern[i]);
+    }
+    nv_rt_shut(&ctx->dev);
+    ctx->live = 0;
+}
+
+/* ---- Kernels ---- */
+
+lfortran_gpu_kernel *lfortran_gpu_load_kernel(
+    lfortran_gpu_ctx *ctx, const char *source, const char *entry_point)
+{
+    char     path[LF_PATH_MAX];
+    uint32_t i;
+    int      rc;
+
+    if (ctx == NULL || entry_point == NULL) lf_die("load_kernel args", 0);
+
+    for (i = 0u; i < LF_MAX_KERN; i++) {
+        if (!g_kern[i].used) break;
+    }
+    if (i == LF_MAX_KERN) lf_die("kernel pool exhausted", (int)LF_MAX_KERN);
+
+    lf_ptx(source, entry_point, path, sizeof path);
+
+    memset(&g_kern[i], 0, sizeof g_kern[i]);
+    rc = nv_rt_load(&ctx->dev, path, entry_point, &g_kern[i].k);
+    if (rc != NV_RT_OK) {
+        fprintf(stderr, "lf_gpu: could not load '%s' from %s\n",
+                entry_point, path);
+        lf_die("nv_rt_load", rc);
+    }
+
+    g_kern[i].used = 1;
+    g_kern[i].ctx  = ctx;
+    return &g_kern[i];
+}
+
+void lfortran_gpu_release_kernel(lfortran_gpu_kernel *k)
+{
+    int j;
+
+    if (k == NULL || !k->used) return;
+
+    for (j = 0; j < k->nargs; j++) {
+        if (k->args[j].is_buf && k->args[j].dptr != 0u) {
+            nv_rt_free(&k->ctx->dev, k->args[j].dptr);
+            k->args[j].dptr = 0u;
+        }
+    }
+    nv_rt_unload(&k->ctx->dev, &k->k);
+    k->used  = 0;
+    k->nargs = 0;
+}
+
+/* ---- Arguments ---- */
+
+/* Buffers are copied host to device here and back again after the launch,
+ * mirroring the CUDA runtime. Fortran hands us plain host arrays and expects
+ * to read results out of the same memory afterwards. */
+void lfortran_gpu_set_buffer_arg(lfortran_gpu_kernel *k, int idx,
+    void *ptr, size_t size)
+{
+    lf_arg_t *a;
+    int       rc;
+
+    if (k == NULL || idx < 0 || (uint32_t)idx >= LF_MAX_ARGS) return;
+
+    a = &k->args[idx];
+    if (a->is_buf && a->dptr != 0u) nv_rt_free(&k->ctx->dev, a->dptr);
+
+    a->dptr = nv_rt_alloc(&k->ctx->dev, size);
+    if (a->dptr == 0u) lf_die("nv_rt_alloc", (int)size);
+
+    rc = nv_rt_h2d(&k->ctx->dev, a->dptr, ptr, size);
+    if (rc != NV_RT_OK) lf_die("nv_rt_h2d", rc);
+
+    a->hptr   = ptr;
+    a->size   = size;
+    a->is_buf = 1;
+    a->used   = 1;
+    if (idx >= k->nargs) k->nargs = idx + 1;
+}
+
+void lfortran_gpu_set_scalar_arg(lfortran_gpu_kernel *k, int idx,
+    const void *val, size_t size)
+{
+    lf_arg_t *a;
+
+    if (k == NULL || idx < 0 || (uint32_t)idx >= LF_MAX_ARGS) return;
+    if (val == NULL || size == 0u || size > LF_SCAL_MAX) {
+        lf_die("scalar arg too wide", (int)size);
+    }
+
+    a = &k->args[idx];
+    memcpy(a->scal, val, size);
+    a->size   = size;
+    a->is_buf = 0;
+    a->used   = 1;
+    if (idx >= k->nargs) k->nargs = idx + 1;
+}
+
+/* ---- Launch ---- */
+
+void lfortran_gpu_launch(lfortran_gpu_ctx *ctx, lfortran_gpu_kernel *k,
+    int grid[3], int block[3])
+{
+    void *argv[LF_MAX_ARGS];
+    int   j, n = 0;
+    int   rc;
+
+    if (ctx == NULL || k == NULL || !k->used) return;
+    if (grid == NULL || block == NULL) lf_die("launch dims", 0);
+    if (grid[0] < 1 || grid[1] < 1 || grid[2] < 1 ||
+        block[0] < 1 || block[1] < 1 || block[2] < 1) {
+        lf_die("launch dims non-positive", grid[0]);
+    }
+
+    /* The driver API wants a pointer to each argument, so buffers pass the
+     * address of the device pointer rather than the pointer itself. */
+    for (j = 0; j < k->nargs; j++) {
+        if (!k->args[j].used) lf_die("argument gap", j);
+        argv[n++] = k->args[j].is_buf ? (void *)&k->args[j].dptr
+                                      : (void *)k->args[j].scal;
+    }
+
+    rc = nv_rt_launch(&ctx->dev, &k->k,
+                      (uint32_t)grid[0],  (uint32_t)grid[1],  (uint32_t)grid[2],
+                      (uint32_t)block[0], (uint32_t)block[1], (uint32_t)block[2],
+                      0u, argv);
+    if (rc != NV_RT_OK) lf_die("nv_rt_launch", rc);
+
+    rc = nv_rt_sync(&ctx->dev);
+    if (rc != NV_RT_OK) lf_die("nv_rt_sync", rc);
+
+    for (j = 0; j < k->nargs; j++) {
+        if (!k->args[j].is_buf || k->args[j].dptr == 0u) continue;
+        rc = nv_rt_d2h(&ctx->dev, k->args[j].hptr,
+                       k->args[j].dptr, k->args[j].size);
+        if (rc != NV_RT_OK) lf_die("nv_rt_d2h", rc);
+    }
+}
+
+void lfortran_gpu_sync(lfortran_gpu_ctx *ctx)
+{
+    if (ctx == NULL || !ctx->live) return;
+    (void)nv_rt_sync(&ctx->dev);
+}

--- a/src/runtime/lf_gpu.c
+++ b/src/runtime/lf_gpu.c
@@ -1,14 +1,9 @@
 /* lf_gpu.c — LFortran GPU offload ABI over the Booth NVIDIA launcher.
  *
- * The ABI returns void and has no error channel, so a failure here is fatal
- * and loud. Carrying on after a failed H2D copy would hand Fortran a result
- * array full of whatever was in device memory, which is the one outcome
- * worse than stopping.
- *
- * Kernels are PTX on disk, produced by kath from the .cu LFortran emits.
- * The CUDA runtime gets its kernel from a static registrar linked into the
- * host object; we have no such hook, so the path is resolved at load time.
- */
+ * The ABI is void-returning with no error channel, so failure is fatal and
+ * loud: a silent bad copy hands Fortran an array of garbage, which is worse.
+ * Kernels are PTX on disk, so we resolve the path at load time rather than
+ * lean on the static registrar the CUDA runtime links in. */
 
 #include "lf_gpu.h"
 #include "nv_rt.h"
@@ -63,8 +58,7 @@ static void lf_die(const char *what, int rc)
     exit(1);
 }
 
-/* Where to find the PTX. An explicit source string wins, then BOOTH_PTX for
- * the case where the build put it somewhere odd, then the kernel name. */
+/* Find the PTX: explicit source, then $BOOTH_PTX, then <kernel>.ptx. */
 static void lf_ptx(const char *source, const char *entry,
                    char *out, size_t cap)
 {
@@ -160,9 +154,8 @@ void lfortran_gpu_release_kernel(lfortran_gpu_kernel *k)
 
 /* ---- Arguments ---- */
 
-/* Buffers are copied host to device here and back again after the launch,
- * mirroring the CUDA runtime. Fortran hands us plain host arrays and expects
- * to read results out of the same memory afterwards. */
+/* Copy in now, out after the launch: Fortran reads results from the same
+ * host array it handed us. */
 void lfortran_gpu_set_buffer_arg(lfortran_gpu_kernel *k, int idx,
     void *ptr, size_t size)
 {
@@ -221,8 +214,7 @@ void lfortran_gpu_launch(lfortran_gpu_ctx *ctx, lfortran_gpu_kernel *k,
         lf_die("launch dims non-positive", grid[0]);
     }
 
-    /* The driver API wants a pointer to each argument, so buffers pass the
-     * address of the device pointer rather than the pointer itself. */
+    /* Driver API wants a pointer to each arg, so buffers pass &dptr. */
     for (j = 0; j < k->nargs; j++) {
         if (!k->args[j].used) lf_die("argument gap", j);
         argv[n++] = k->args[j].is_buf ? (void *)&k->args[j].dptr

--- a/src/runtime/lf_gpu.h
+++ b/src/runtime/lf_gpu.h
@@ -1,14 +1,10 @@
 /* lf_gpu.h — LFortran GPU offload ABI, Booth implementation
  *
- * LFortran lowers `do concurrent` to a kernel plus a handful of calls into
- * a device-agnostic runtime. Implement these eight functions and LFortran
- * can target Booth without either project depending on the other; the CUDA
- * and Metal runtimes in its tree are siblings of this one.
- *
- * Declared here rather than including LFortran's header so the build stays
- * self-contained. The signatures are an ABI contract and must match
- * libasr/runtime/lfortran_gpu_runtime.h exactly or the link will lie.
- */
+ * Eight functions LFortran calls to run a `do concurrent` kernel; a sibling
+ * of the CUDA and Metal runtimes in its tree, so neither project depends on
+ * the other. Our own declaration, not LFortran's header, so the build stays
+ * self-contained — but it must match libasr/runtime/lfortran_gpu_runtime.h
+ * exactly or the link will lie. */
 
 #ifndef BARRACUDA_LF_GPU_H
 #define BARRACUDA_LF_GPU_H

--- a/src/runtime/lf_gpu.h
+++ b/src/runtime/lf_gpu.h
@@ -1,0 +1,45 @@
+/* lf_gpu.h — LFortran GPU offload ABI, Booth implementation
+ *
+ * LFortran lowers `do concurrent` to a kernel plus a handful of calls into
+ * a device-agnostic runtime. Implement these eight functions and LFortran
+ * can target Booth without either project depending on the other; the CUDA
+ * and Metal runtimes in its tree are siblings of this one.
+ *
+ * Declared here rather than including LFortran's header so the build stays
+ * self-contained. The signatures are an ABI contract and must match
+ * libasr/runtime/lfortran_gpu_runtime.h exactly or the link will lie.
+ */
+
+#ifndef BARRACUDA_LF_GPU_H
+#define BARRACUDA_LF_GPU_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct lfortran_gpu_ctx    lfortran_gpu_ctx;
+typedef struct lfortran_gpu_kernel lfortran_gpu_kernel;
+
+lfortran_gpu_ctx*    lfortran_gpu_init(void);
+void                 lfortran_gpu_shutdown(lfortran_gpu_ctx *ctx);
+
+lfortran_gpu_kernel* lfortran_gpu_load_kernel(
+    lfortran_gpu_ctx *ctx, const char *source, const char *entry_point);
+void                 lfortran_gpu_release_kernel(lfortran_gpu_kernel *k);
+
+void lfortran_gpu_set_buffer_arg(lfortran_gpu_kernel *k, int idx,
+    void *ptr, size_t size);
+void lfortran_gpu_set_scalar_arg(lfortran_gpu_kernel *k, int idx,
+    const void *val, size_t size);
+
+void lfortran_gpu_launch(lfortran_gpu_ctx *ctx, lfortran_gpu_kernel *k,
+    int grid[3], int block[3]);
+void lfortran_gpu_sync(lfortran_gpu_ctx *ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BARRACUDA_LF_GPU_H */

--- a/src/runtime/lf_gpu_hsa.c
+++ b/src/runtime/lf_gpu_hsa.c
@@ -1,0 +1,273 @@
+/* lf_gpu_hsa.c — LFortran GPU offload ABI over the Booth HSA launcher.
+ *
+ * The AMD sibling of lf_gpu.c. Same eight functions, same contract, but the
+ * kernel is a .hsaco run through bc_runtime instead of PTX through nv_rt, so an
+ * LFortran-compiled program can offload to an AMD GPU. The build links one or
+ * the other into the Fortran executable depending on the target; they can't
+ * coexist, they define the same symbols.
+ *
+ * HSA takes a single packed kernarg blob rather than an array of arg pointers,
+ * so launch assembles it here: each parameter in an 8-byte slot, then the
+ * hidden block_count/group_size the AMD isel reads for blockDim/gridDim. The
+ * layout matches the one the RDNA emulator checks in tests/numeric.
+ *
+ * Linux/ROCm only. End-to-end verification needs a real AMD GPU (MI300X); the
+ * kernarg layout and bc_runtime path are each proven elsewhere, but the two
+ * have not yet been run together on hardware.
+ */
+
+#include "lf_gpu.h"
+#include "bc_runtime.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+/* ---- Limits ---- */
+
+#define LF_MAX_ARGS  32u
+#define LF_MAX_KERN   8u
+#define LF_SCAL_MAX  16u
+#define LF_PATH_MAX 512u
+#define LF_KARG_MAX (LF_MAX_ARGS * 8u + 32u)   /* params + hidden args */
+
+/* ---- State ---- */
+
+struct lfortran_gpu_ctx {
+    bc_device_t dev;
+    int         live;
+};
+
+typedef struct {
+    void   *hptr;                 /* host array, for the copy back */
+    void   *dptr;                 /* device allocation */
+    size_t  size;
+    uint8_t scal[LF_SCAL_MAX];
+    size_t  scal_sz;
+    int     is_buf;
+    int     used;
+} lf_arg_t;
+
+struct lfortran_gpu_kernel {
+    bc_kernel_t k;
+    lf_arg_t    args[LF_MAX_ARGS];
+    int         nargs;
+    int         used;
+    lfortran_gpu_ctx *ctx;
+};
+
+static lfortran_gpu_ctx    g_ctx;
+static lfortran_gpu_kernel g_kern[LF_MAX_KERN];
+
+/* ---- Helpers ---- */
+
+static void lf_die(const char *what, int rc)
+{
+    fprintf(stderr, "lf_gpu_hsa: %s failed (rc=%d)\n", what, rc);
+    exit(1);
+}
+
+/* Where to find the hsaco: explicit source, then $BOOTH_HSACO, then <name>. */
+static void lf_hsaco(const char *source, const char *entry,
+                     char *out, size_t cap)
+{
+    const char *env;
+
+    if (source != NULL && source[0] != '\0') {
+        (void)snprintf(out, cap, "%s", source);
+        return;
+    }
+    env = getenv("BOOTH_HSACO");
+    if (env != NULL && env[0] != '\0') {
+        (void)snprintf(out, cap, "%s", env);
+        return;
+    }
+    (void)snprintf(out, cap, "%s.hsaco", entry);
+}
+
+/* ---- Lifecycle ---- */
+
+lfortran_gpu_ctx *lfortran_gpu_init(void)
+{
+    int rc;
+
+    if (g_ctx.live) return &g_ctx;
+
+    rc = bc_device_init(&g_ctx.dev);
+    if (rc != BC_RT_OK) lf_die("bc_device_init", rc);
+
+    g_ctx.live = 1;
+    return &g_ctx;
+}
+
+void lfortran_gpu_shutdown(lfortran_gpu_ctx *ctx)
+{
+    uint32_t i;
+
+    if (ctx == NULL || !ctx->live) return;
+
+    for (i = 0u; i < LF_MAX_KERN; i++) {
+        if (g_kern[i].used) lfortran_gpu_release_kernel(&g_kern[i]);
+    }
+    bc_device_shutdown(&ctx->dev);
+    ctx->live = 0;
+}
+
+/* ---- Kernels ---- */
+
+lfortran_gpu_kernel *lfortran_gpu_load_kernel(
+    lfortran_gpu_ctx *ctx, const char *source, const char *entry_point)
+{
+    char     path[LF_PATH_MAX];
+    uint32_t i;
+    int      rc;
+
+    if (ctx == NULL || entry_point == NULL) lf_die("load_kernel args", 0);
+
+    for (i = 0u; i < LF_MAX_KERN; i++) {
+        if (!g_kern[i].used) break;
+    }
+    if (i == LF_MAX_KERN) lf_die("kernel pool exhausted", (int)LF_MAX_KERN);
+
+    lf_hsaco(source, entry_point, path, sizeof path);
+
+    memset(&g_kern[i], 0, sizeof g_kern[i]);
+    rc = bc_load_kernel(&ctx->dev, path, entry_point, &g_kern[i].k);
+    if (rc != BC_RT_OK) {
+        fprintf(stderr, "lf_gpu_hsa: could not load '%s' from %s\n",
+                entry_point, path);
+        lf_die("bc_load_kernel", rc);
+    }
+
+    g_kern[i].used = 1;
+    g_kern[i].ctx  = ctx;
+    return &g_kern[i];
+}
+
+void lfortran_gpu_release_kernel(lfortran_gpu_kernel *k)
+{
+    int j;
+
+    if (k == NULL || !k->used) return;
+
+    for (j = 0; j < k->nargs; j++) {
+        if (k->args[j].is_buf && k->args[j].dptr != NULL) {
+            bc_free(&k->ctx->dev, k->args[j].dptr);
+            k->args[j].dptr = NULL;
+        }
+    }
+    bc_unload_kernel(&k->ctx->dev, &k->k);
+    k->used  = 0;
+    k->nargs = 0;
+}
+
+/* ---- Arguments ---- */
+
+void lfortran_gpu_set_buffer_arg(lfortran_gpu_kernel *k, int idx,
+    void *ptr, size_t size)
+{
+    lf_arg_t *a;
+    int       rc;
+
+    if (k == NULL || idx < 0 || (uint32_t)idx >= LF_MAX_ARGS) return;
+
+    a = &k->args[idx];
+    if (a->is_buf && a->dptr != NULL) bc_free(&k->ctx->dev, a->dptr);
+
+    a->dptr = bc_alloc(&k->ctx->dev, size);
+    if (a->dptr == NULL) lf_die("bc_alloc", (int)size);
+
+    rc = bc_copy_h2d(&k->ctx->dev, a->dptr, ptr, size);
+    if (rc != BC_RT_OK) lf_die("bc_copy_h2d", rc);
+
+    a->hptr    = ptr;
+    a->size    = size;
+    a->is_buf  = 1;
+    a->used    = 1;
+    if (idx >= k->nargs) k->nargs = idx + 1;
+}
+
+void lfortran_gpu_set_scalar_arg(lfortran_gpu_kernel *k, int idx,
+    const void *val, size_t size)
+{
+    lf_arg_t *a;
+
+    if (k == NULL || idx < 0 || (uint32_t)idx >= LF_MAX_ARGS) return;
+    if (val == NULL || size == 0u || size > LF_SCAL_MAX) {
+        lf_die("scalar arg too wide", (int)size);
+    }
+
+    a = &k->args[idx];
+    memcpy(a->scal, val, size);
+    a->scal_sz = size;
+    a->is_buf  = 0;
+    a->used    = 1;
+    if (idx >= k->nargs) k->nargs = idx + 1;
+}
+
+/* ---- Launch ---- */
+
+void lfortran_gpu_launch(lfortran_gpu_ctx *ctx, lfortran_gpu_kernel *k,
+    int grid[3], int block[3])
+{
+    uint8_t  karg[LF_KARG_MAX];
+    uint32_t slot = 0u, hk;
+    int      j, rc;
+
+    if (ctx == NULL || k == NULL || !k->used) return;
+    if (grid == NULL || block == NULL) lf_die("launch dims", 0);
+    if (grid[0] < 1 || grid[1] < 1 || grid[2] < 1 ||
+        block[0] < 1 || block[1] < 1 || block[2] < 1) {
+        lf_die("launch dims non-positive", grid[0]);
+    }
+
+    memset(karg, 0, sizeof karg);
+
+    /* One 8-byte slot per parameter: a buffer contributes its device pointer,
+       a scalar its value in the low bytes. */
+    for (j = 0; j < k->nargs; j++) {
+        if (!k->args[j].used) lf_die("argument gap", j);
+        if (slot + 8u > LF_KARG_MAX) lf_die("kernarg overflow", j);
+        if (k->args[j].is_buf) {
+            void *dp = k->args[j].dptr;
+            memcpy(karg + slot, &dp, sizeof dp);
+        } else {
+            memcpy(karg + slot, k->args[j].scal, k->args[j].scal_sz);
+        }
+        slot += 8u;
+    }
+
+    /* Hidden kernarg the AMD isel reads for gridDim/blockDim: block_count as
+       three u32, then group_size as three u16. grid = workgroups, block =
+       work-items per group. */
+    hk = slot;
+    if (hk + 18u > LF_KARG_MAX) lf_die("hidden kernarg overflow", (int)hk);
+    {
+        uint32_t bc3[3] = { (uint32_t)grid[0], (uint32_t)grid[1], (uint32_t)grid[2] };
+        uint16_t gs3[3] = { (uint16_t)block[0], (uint16_t)block[1], (uint16_t)block[2] };
+        memcpy(karg + hk,       bc3, sizeof bc3);
+        memcpy(karg + hk + 12u, gs3, sizeof gs3);
+    }
+
+    rc = bc_dispatch(&ctx->dev, &k->k,
+                     (uint32_t)grid[0],  (uint32_t)grid[1],  (uint32_t)grid[2],
+                     (uint32_t)block[0], (uint32_t)block[1], (uint32_t)block[2],
+                     karg, hk + 18u);
+    if (rc != BC_RT_OK) lf_die("bc_dispatch", rc);
+
+    /* bc_dispatch is synchronous, so results are ready. Copy each output
+       buffer back into the host array Fortran handed us. */
+    for (j = 0; j < k->nargs; j++) {
+        if (!k->args[j].is_buf || k->args[j].dptr == NULL) continue;
+        rc = bc_copy_d2h(&ctx->dev, k->args[j].hptr,
+                         k->args[j].dptr, k->args[j].size);
+        if (rc != BC_RT_OK) lf_die("bc_copy_d2h", rc);
+    }
+}
+
+void lfortran_gpu_sync(lfortran_gpu_ctx *ctx)
+{
+    /* bc_dispatch already blocks, so there is nothing outstanding to wait on. */
+    (void)ctx;
+}

--- a/src/runtime/lf_gpu_hsa.c
+++ b/src/runtime/lf_gpu_hsa.c
@@ -11,9 +11,8 @@
  * hidden block_count/group_size the AMD isel reads for blockDim/gridDim. The
  * layout matches the one the RDNA emulator checks in tests/numeric.
  *
- * Linux/ROCm only. End-to-end verification needs a real AMD GPU (MI300X); the
- * kernarg layout and bc_runtime path are each proven elsewhere, but the two
- * have not yet been run together on hardware.
+ * Linux/ROCm only. Smoke-tested on an MI300X (CDNA): a do-concurrent kernel
+ * offloads through here and comes back with the right answer.
  */
 
 #include "lf_gpu.h"


### PR DESCRIPTION
LFortran lowers `do concurrent` to a kernel plus a handful of calls into a device-agnostic runtime, eight functions with no vendor types in them, the seam Metal forced open. Fill those in and LFortran offloads straight to Booth.

Two implementations of that ABI live here: lf_gpu.c runs PTX through nv_rt, lf_gpu_hsa.c runs a .hsaco through bc_runtime. The Fortran build links whichever matches the target. Upshot: one saxpy.f90 with a do-concurrent loop runs on a 4060 Ti and on an MI300X, same source, through Booth. Neither project depends on the other, the runtime is our own file matched to LFortran's ABI.