### PR TITLE
backend: introduce be_desc_t contract and static registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,17 @@ Booth — Changelog
 - #137: support bare convergent warp and lane intrinsics
   (Maou, 2026-07-27)
 
+### Architecture
+
+- introduce a backend contract (`be_desc_t`) and a static registration
+  list so adding a new backend is a weekend project rather than a
+  career decision; every existing backend now sits behind the same
+  eight-op shape (is_on, isel, sched, regalloc, verify, emit, mfree),
+  the driver iterates `be_list` instead of a copy-pasted if-chain,
+  and a reference skeleton in `src/backend/skeleton/` plus
+  `docs/backends.md` document the walkthrough for external contributors
+  (Zane Hambly, 2026-08-02)
+
 ### Backends
 
 - seed atomic RMW as divergent in the AMD divergence analysis, so a GEP off

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ CFLAGS  = -std=c99 -MMD -MP -Wall -Wextra -pedantic -O2 \
           -Wdouble-promotion -Wswitch-enum -Wwrite-strings \
           -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fPIE $(CF_PROT) \
           $(GCC_ONLY) \
-          -Isrc -Isrc/fe -Isrc/ir -Isrc/tdf -Isrc/amdgpu -Isrc/tensix -Isrc/nvidia -Isrc/metal -Isrc/intel -Isrc/triton -Isrc/cpu -Isrc/runtime
+          -Isrc -Isrc/fe -Isrc/ir -Isrc/tdf -Isrc/backend -Isrc/amdgpu -Isrc/tensix -Isrc/nvidia -Isrc/metal -Isrc/intel -Isrc/triton -Isrc/cpu -Isrc/runtime
 LDFLAGS = -pie
 LIBS    = -lm
 # Linux/ELF only: -Wl,-z,relro,-z,now -Wl,-z,noexecstack
@@ -60,12 +60,13 @@ SOURCES = src/main.c \
           src/fe/bc_err.c src/fe/bc_render.c src/fe/preproc.c src/fe/lexer.c src/fe/parser.c src/fe/sema.c \
           src/ir/bir.c src/ir/bir_print.c src/ir/bir_lower.c src/ir/bir_mem2reg.c src/ir/bir_cfold.c src/ir/bir_dce.c src/ir/bir_struct.c src/ir/bir_insert.c src/ir/bir_sroa.c src/ir/bir_inline.c \
           src/tdf/tdf.c src/tdf/tdf_lower.c src/tdf/tdf_fission.c src/tdf/tdf_place.c src/tdf/tdf_noc.c \
-          src/amdgpu/amd_rplan.c src/amdgpu/isel.c src/amdgpu/emit.c src/amdgpu/ra_ssa.c src/amdgpu/encode.c src/amdgpu/enc_tab.c src/amdgpu/sched.c src/amdgpu/verify.c \
+          src/backend/backends.c \
+          src/amdgpu/amd_rplan.c src/amdgpu/isel.c src/amdgpu/emit.c src/amdgpu/ra_ssa.c src/amdgpu/encode.c src/amdgpu/enc_tab.c src/amdgpu/sched.c src/amdgpu/verify.c src/amdgpu/amd_be.c \
           src/tensix/isel.c src/tensix/emit.c src/tensix/coarsen.c src/tensix/datamov.c src/tensix/noc.c \
-          src/tensix/rv_enc.c src/tensix/rv_buf.c src/tensix/rv_elf.c src/tensix/rv_isel.c src/cpu/cpu_emit.c src/cpu/cpu_elf.c src/cpu/rv64_emit.c src/cpu/rv64_elf.c \
-          src/nvidia/isel.c src/nvidia/emit.c \
-          src/metal/emit.c \
-          src/intel/emit.c \
+          src/tensix/rv_enc.c src/tensix/rv_buf.c src/tensix/rv_elf.c src/tensix/rv_isel.c src/tensix/tensix_be.c src/cpu/cpu_emit.c src/cpu/cpu_elf.c src/cpu/rv64_emit.c src/cpu/rv64_elf.c src/cpu/cpu_be.c \
+          src/nvidia/isel.c src/nvidia/emit.c src/nvidia/nv_be.c \
+          src/metal/emit.c src/metal/metal_be.c \
+          src/intel/emit.c src/intel/intel_be.c \
           src/triton/lex.c src/triton/parse.c src/triton/sema.c src/triton/lower.c
 OBJECTS = $(SOURCES:%.c=$(OBJDIR)/%.o)
 TARGET  = kath
@@ -81,7 +82,7 @@ $(OBJDIR)/%.o: %.c
 
 # ---- Test Suite ----
 TCFLAGS = -std=c99 -MMD -MP -D_POSIX_C_SOURCE=200809L -Wall -Wextra -O0 -g \
-          -Isrc -Isrc/fe -Isrc/ir -Isrc/tdf -Isrc/amdgpu -Isrc/tensix -Isrc/nvidia -Isrc/metal -Isrc/intel -Isrc/triton -Isrc/cpu -Isrc/runtime \
+          -Isrc -Isrc/fe -Isrc/ir -Isrc/tdf -Isrc/backend -Isrc/amdgpu -Isrc/tensix -Isrc/nvidia -Isrc/metal -Isrc/intel -Isrc/triton -Isrc/cpu -Isrc/runtime \
           -Iruntime
 TSRC    = tests/tmain.c tests/tsmoke.c tests/tcomp.c tests/tenc.c \
           tests/ttabs.c tests/ttypes.c tests/terrs.c tests/tphase.c \
@@ -102,7 +103,8 @@ TSRC    = tests/tmain.c tests/tsmoke.c tests/tcomp.c tests/tenc.c \
           tests/trv_enc.c tests/trv_buf.c tests/trv_elf.c tests/trv_isel.c \
           tests/tcbsync.c \
           tests/tsoft_fp.c \
-          tests/tsysprint.c
+          tests/tsysprint.c \
+          tests/tbackend.c
 
 TOBJS   = $(TSRC:%.c=$(OBJDIR)/%.o)
 COBJS   = $(OBJDIR)/src/ir/bir.o $(OBJDIR)/src/ir/bir_print.o $(OBJDIR)/src/ir/bir_lower.o $(OBJDIR)/src/ir/bir_mem2reg.o $(OBJDIR)/src/ir/bir_cfold.o $(OBJDIR)/src/ir/bir_dce.o $(OBJDIR)/src/ir/bir_struct.o $(OBJDIR)/src/ir/bir_insert.o $(OBJDIR)/src/ir/bir_sroa.o $(OBJDIR)/src/ir/bir_inline.o \
@@ -111,7 +113,16 @@ COBJS   = $(OBJDIR)/src/ir/bir.o $(OBJDIR)/src/ir/bir_print.o $(OBJDIR)/src/ir/b
           $(OBJDIR)/runtime/soft_fp.o $(OBJDIR)/runtime/sysprint.o \
           $(OBJDIR)/src/amdgpu/amd_rplan.o $(OBJDIR)/src/amdgpu/encode.o $(OBJDIR)/src/amdgpu/enc_tab.o $(OBJDIR)/src/amdgpu/isel.o $(OBJDIR)/src/amdgpu/emit.o $(OBJDIR)/src/amdgpu/ra_ssa.o $(OBJDIR)/src/amdgpu/sched.o $(OBJDIR)/src/amdgpu/verify.o \
           $(OBJDIR)/src/fe/bc_err.o $(OBJDIR)/src/fe/lexer.o $(OBJDIR)/src/fe/parser.o $(OBJDIR)/src/fe/preproc.o $(OBJDIR)/src/fe/sema.o \
-          $(OBJDIR)/src/runtime/bc_abend.o $(HOSTRT)
+          $(OBJDIR)/src/runtime/bc_abend.o $(HOSTRT) \
+          $(OBJDIR)/src/backend/backends.o \
+          $(OBJDIR)/src/amdgpu/amd_be.o $(OBJDIR)/src/nvidia/nv_be.o \
+          $(OBJDIR)/src/tensix/tensix_be.o $(OBJDIR)/src/cpu/cpu_be.o \
+          $(OBJDIR)/src/metal/metal_be.o $(OBJDIR)/src/intel/intel_be.o \
+          $(OBJDIR)/src/nvidia/isel.o $(OBJDIR)/src/nvidia/emit.o \
+          $(OBJDIR)/src/cpu/cpu_emit.o $(OBJDIR)/src/cpu/cpu_elf.o \
+          $(OBJDIR)/src/cpu/rv64_emit.o $(OBJDIR)/src/cpu/rv64_elf.o \
+          $(OBJDIR)/src/tensix/isel.o $(OBJDIR)/src/tensix/coarsen.o $(OBJDIR)/src/tensix/datamov.o \
+          $(OBJDIR)/src/metal/emit.o $(OBJDIR)/src/intel/emit.o
 
 test: $(TARGET) trunner
 	./trunner --all

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -1,0 +1,150 @@
+# Backend Authoring
+
+Hello human or LLM asked to clone this. If you are here because you want to add a new backend to Booth, or promote a stub to first-class, you are in the right place. The whole shape is in `src/backend/backend.h` plus the reference skeleton in `src/backend/skeleton/`. This document walks the pipeline, the contract, and the recipe.
+
+## The pipeline
+
+BIR comes in, machine bytes go out. Between those two ends, Booth's backend contract splits the work into named phases:
+
+```
+  BIR module -> isel -> [sched] -> [regalloc] -> [verify] -> emit -> file(s)
+                             (optional phases in brackets)
+```
+
+Each phase is a function pointer on the backend's `be_desc_t` descriptor. Optional phases with a NULL pointer are skipped by the driver. Only `isel` and `emit` are strictly required.
+
+- **isel**: consume the BIR module, produce a backend-specific machine module (`void *`). This is where all your target-specific instruction selection lives.
+- **sched**: reorder instructions for latency, throughput, whatever your target cares about. Skip if you have nothing to do here.
+- **regalloc**: assign physical registers. Skip if your emitter goes straight from BIR values to instructions (the CPU backend does this).
+- **verify**: sanity check the machine module at each defined phase (`BE_VFY_ISEL`, `BE_VFY_RA`). Skip if you have no invariants to check. AMD's `bc_vfy` is a good reference.
+- **emit**: write the final output(s) to disk. Required. Multi-file backends (like Tensix Metalium) do everything inside their `emit` and set the `BE_F_MULTIOUT` feature flag.
+- **mfree**: free the backend module that `isel` allocated.
+
+## The contract
+
+`src/backend/backend.h` defines everything. The two important types:
+
+```c
+typedef struct be_desc {
+    const char *name;              /* stable id */
+    const char *triple;            /* target triple, or NULL */
+    uint32_t    feats;             /* BE_F_* bitmask */
+
+    int  (*is_on)  (const struct be_cfg *cfg);
+    int  (*isel)   (const struct bir_module *M, const struct be_cfg *cfg,
+                    void **out_mmod);
+    int  (*sched)  (void *mmod);
+    int  (*regalc) (void *mmod);
+    int  (*verify) (const void *mmod, int phase);
+    int  (*emit)   (const void *mmod, const struct be_cfg *cfg,
+                    const char *out_path);
+    void (*mfree)  (void *mmod);
+} be_desc_t;
+```
+
+Return codes come from `be_ret_t`: `BE_OK` on success, negative on failure (`BE_EISEL`, `BE_ERA`, `BE_EEMIT`, etc.), `BE_UNSUP` when the op deliberately does not apply.
+
+`is_on(cfg)` returns non-zero when the backend should run for this invocation. Typically this reads a `mode_*` field from `be_cfg_t`. See `src/backend/backend_cfg.h` for the config layout.
+
+`cfg` is opaque in the header and typed in the backend implementation. Backends cast to `be_cfg_t` and read what they need. If your backend needs a new knob, add a field to `be_cfg_t`, populate it from the CLI parser in `src/main.c`, read it from your descriptor.
+
+## Feature flags
+
+Declare only what you honestly implement. The conformance suite (coming in Phase B) will run the tests matching your declared features and fail loudly if you oversell.
+
+```c
+BE_F_SIMT      /* SIMT execution model */
+BE_F_SCALAR    /* scalar / stack-everything */
+BE_F_ATOMIC    /* atomic RMW family */
+BE_F_SHARED    /* per-block shared memory */
+BE_F_WARP      /* shfl, ballot, vote */
+BE_F_MFMA      /* matrix multiply-accumulate */
+BE_F_BARRIER   /* __syncthreads equivalent */
+BE_F_DIV       /* per-lane divergence handling */
+BE_F_SCRATCH   /* per-thread private */
+BE_F_TRANSC    /* sin, cos, exp2, log2 */
+BE_F_F16       /* 16-bit float */
+BE_F_F64       /* 64-bit float */
+BE_F_BF16      /* brain float */
+BE_F_MULTIOUT  /* emits multiple files (Tensix) */
+```
+
+## The recipe: adding a new backend
+
+Say you are adding support for a new accelerator called `mygpu`.
+
+**1. Copy the skeleton.**
+
+```bash
+cp -r src/backend/skeleton src/backend/mygpu
+```
+
+**2. Rename inside.** The skeleton uses the prefix `skel_`; rename to `mygpu_` throughout.
+
+**3. Register the descriptor.** In `src/backend/backends.c`:
+
+```c
+extern const be_desc_t be_mygpu;    /* add near the other externs */
+
+const be_desc_t * const be_list[] = {
+    &be_amd,
+    ...
+    &be_mygpu,                       /* add to the list */
+    NULL
+};
+```
+
+**4. Wire up the build.** In the top-level `Makefile`, add `src/backend/mygpu/mygpu.c` to `SOURCES`. Also add `-Isrc/backend/mygpu` to `CFLAGS` and `TCFLAGS` if you split into multiple files.
+
+**5. Add a mode flag.** In `src/backend/backend_cfg.h`, add `int mode_mygpu;` to `be_cfg_t`. In `src/main.c`'s CLI parser, add `--mygpu` handling that sets `mode_mygpu = 1`.
+
+**6. Implement `isel` first.** This is where you consume the BIR module and produce your machine module. Look at `src/nvidia/nv_be.c` for the simplest full example, or `src/amdgpu/amd_be.c` for the full-pipeline shape.
+
+**7. Implement `emit`.** Write the output file(s) to disk. Return `BE_OK` or `BE_EEMIT`.
+
+**8. Declare features you have implemented** in the descriptor. Start with zero, add flags as ops start working.
+
+**9. Run the conformance suite.** (Coming in Phase B.)
+
+```bash
+make backend-conformance BACKEND=mygpu
+```
+
+The suite runs the tests matching your declared features. Green means you are done for that feature set.
+
+## Reference backends by shape
+
+- **Simplest full example**: `src/nvidia/nv_be.c`. Isel + emit only. About 50 lines.
+- **Full pipeline including sched, regalloc, and verify**: `src/amdgpu/amd_be.c`. 90 lines of wrappers over the existing AMDGPU internals.
+- **Multi-output**: `src/tensix/tensix_be.c`. Emit writes compute + reader + writer + host + several binary artefacts, all derived from one output-path stem. Sets `BE_F_MULTIOUT` in the descriptor.
+- **Scalar / stack-everything**: `src/cpu/cpu_be.c`. No sched or regalloc, isel and emit only, `BE_F_SCALAR` in the flags.
+- **Stub-level starting point**: `src/intel/intel_be.c`. Same shape as the others but the underlying `intel_compile` returns "not yet a working compiler." Useful as an example of a backend under construction.
+
+## Contract invariants
+
+- Every registered backend must have `name`, `is_on`, `isel`, `emit`. `be_list_ok` in `tests/tbackend.c` asserts this.
+- `is_on(cfg)` must be cheap and free of side effects. It is called on every dispatch.
+- `isel` allocates the machine module. `mfree` frees it. If your isel does not allocate, `mfree` can be NULL.
+- If your `verify` is set, expect it to be called at `BE_VFY_ISEL` and `BE_VFY_RA`. Handle any phase you do not care about by returning `BE_OK`.
+- Return `BE_UNSUP` from an op that is intentionally not implemented. The driver treats this as a real error (you registered the backend, you promised to run).
+
+## JPL discipline
+
+Booth's project rules apply to backends too:
+
+- No dynamic allocation in hot paths. Bounded pools where you can.
+- No recursion in codegen.
+- Bounded loops; if you iterate to a fixpoint, have a guard counter.
+- Bounds-check array accesses from external or untrusted indices.
+- Check return values. Handle the failure path.
+- No floats where integers will do.
+
+See `CONTRIBUTING.md` for the rest.
+
+## Where to go from here
+
+- File a `good-first-backend` issue if you are stuck partway.
+- Read `docs/mainframe.md` for the ABEND / SNAP / SYSPRINT diagnostic conventions that every backend inherits.
+- The conformance suite (Phase B) and shared substrate (Phase C, `src/be_common/`) are on the roadmap.
+
+Adding a new backend or promoting a stub to first-class should be a weekend project. If it turns into a career, something is wrong and I want to hear about it.

--- a/src/amdgpu/amd_be.c
+++ b/src/amdgpu/amd_be.c
@@ -1,0 +1,100 @@
+/* amd_be.c -- AMDGPU as a be_desc_t.
+ *
+ * Thin wrappers around the existing amdgpu_* API. This file is the
+ * whole story of "AMDGPU as a Booth backend"; the rest of src/amdgpu/
+ * is the implementation. */
+
+#include "backend.h"
+#include "backend_cfg.h"
+#include "amdgpu.h"
+#include "sched.h"
+#include "verify.h"
+#include "barracuda.h"     /* BC_OK, BC_ERR_* */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int amd_on(const be_cfg_t *cfg)
+{
+    return cfg->mode_amdgpu || cfg->mode_amdgpu_bin;
+}
+
+static int amd_isel(const struct bir_module *M,
+                    const be_cfg_t *cfg,
+                    void **out_mmod)
+{
+    amd_module_t *amd = (amd_module_t *)calloc(1, sizeof(amd_module_t));
+    if (amd == NULL) return BE_ENOMEM;
+
+    amd->target    = cfg->amd_target;
+    amd->elf_mach  = cfg->amd_elfm;
+    amd->snap_mode = (uint8_t)cfg->snap_mode;
+    snprintf(amd->chip_name, sizeof(amd->chip_name), "%s",
+             cfg->amd_chip ? cfg->amd_chip : "");
+
+    int rc = amdgpu_compile((const bir_module_t *)M, amd);
+    if (rc != BC_OK) {
+        free(amd);
+        *out_mmod = NULL;
+        return BE_EISEL;
+    }
+    *out_mmod = amd;
+    return BE_OK;
+}
+
+static int amd_sched(void *mmod)
+{
+    amdgpu_sched((amd_module_t *)mmod);
+    return BE_OK;
+}
+
+static int amd_regalc(void *mmod)
+{
+    amdgpu_regalloc((amd_module_t *)mmod);
+    return BE_OK;
+}
+
+static int amd_verify(const void *mmod, int phase)
+{
+    int p = (phase == BE_VFY_ISEL) ? VFY_ISEL : VFY_RA;
+    vfy_res_t v = bc_vfy((const amd_module_t *)mmod, p);
+    if (v.errs > 0) {
+        fprintf(stderr, "verify: %u error(s) after %s\n",
+                v.errs, (p == VFY_ISEL) ? "isel" : "regalloc");
+        return BE_EVFY;
+    }
+    return BE_OK;
+}
+
+static int amd_emit(const void *mmod, const be_cfg_t *cfg,
+                    const char *out_path)
+{
+    amd_module_t *amd = (amd_module_t *)mmod;
+    if (cfg->mode_amdgpu_bin) {
+        const char *p = out_path ? out_path : "a.hsaco";
+        int rc = amdgpu_emit_elf(amd, p);
+        return (rc == 0) ? BE_OK : BE_EEMIT;
+    }
+    amdgpu_emit_asm(amd, stdout);
+    return BE_OK;
+}
+
+static void amd_free(void *mmod)
+{
+    free(mmod);
+}
+
+const be_desc_t be_amd = {
+    .name    = "amdgpu",
+    .triple  = "amdgcn--",
+    .feats   = BE_F_SIMT | BE_F_ATOMIC | BE_F_SHARED | BE_F_WARP
+             | BE_F_BARRIER | BE_F_DIV | BE_F_SCRATCH | BE_F_TRANSC
+             | BE_F_F16 | BE_F_F64 | BE_F_MFMA,
+    .is_on   = amd_on,
+    .isel    = amd_isel,
+    .sched   = amd_sched,
+    .regalc  = amd_regalc,
+    .verify  = amd_verify,
+    .emit    = amd_emit,
+    .mfree   = amd_free
+};

--- a/src/backend/backend.h
+++ b/src/backend/backend.h
@@ -1,0 +1,122 @@
+/* backend.h -- the contract every Booth backend implements.
+ *
+ * Hello human or LLM asked to clone this: welcome. If you are here
+ * because you want to add a new backend, the whole show is in this
+ * file plus src/backend/skeleton/. Copy skeleton, edit copy, register
+ * in backends.c, done. See docs/backends.md for the walkthrough.
+ *
+ * The contract is a struct of function pointers. Backends fill in
+ * what they support and leave the rest NULL. The driver iterates a
+ * static registration list, calls each active backend, moves on.
+ *
+ * JPL discipline: no dynamic dispatch by name lookup in hot paths,
+ * bounded static list, every op has a defined return convention,
+ * NULL means "not this backend" not "silently succeed". */
+
+#ifndef BOOTH_BE_H
+#define BOOTH_BE_H
+
+#include <stdint.h>
+
+/* Forward declarations. Backends see the full types via their own
+ * headers; the contract itself does not need to know the shapes. */
+struct bir_module;
+struct be_cfg;
+
+/* ---- Return codes ----
+ * Zero is success. Negative is a defined failure. Positive currently
+ * unused, reserved for warnings if we ever want them. */
+typedef enum {
+    BE_OK           =  0,
+    BE_UNSUP        = -1,  /* op deliberately not implemented */
+    BE_EISEL        = -2,
+    BE_ESCHED       = -3,
+    BE_ERA          = -4,
+    BE_EVFY         = -5,
+    BE_EEMIT        = -6,
+    BE_EIO          = -7,
+    BE_EINPUT       = -8,
+    BE_ENOMEM       = -9
+} be_ret_t;
+
+/* ---- Verify phase ----
+ * Backends with a verifier get called at each phase; they decide
+ * which ones actually run checks. */
+typedef enum {
+    BE_VFY_ISEL,
+    BE_VFY_SCHED,
+    BE_VFY_RA,
+    BE_VFY_EMIT
+} be_vfy_t;
+
+/* ---- Feature flags ----
+ * Backends declare what they honestly implement. Conformance suite
+ * (Phase B) runs the tests matching declared features. If your bit
+ * is set the tests will call you on it, so don't oversell. */
+#define BE_F_SIMT       (1u <<  0)  /* SIMT execution model */
+#define BE_F_SCALAR     (1u <<  1)  /* scalar / stack-everything */
+#define BE_F_ATOMIC     (1u <<  2)  /* atomic RMW family */
+#define BE_F_SHARED     (1u <<  3)  /* per-block shared memory */
+#define BE_F_WARP       (1u <<  4)  /* shfl, ballot, vote */
+#define BE_F_MFMA       (1u <<  5)  /* matrix multiply-accumulate */
+#define BE_F_BARRIER    (1u <<  6)  /* __syncthreads equivalent */
+#define BE_F_DIV        (1u <<  7)  /* per-lane divergence handling */
+#define BE_F_SCRATCH    (1u <<  8)  /* per-thread private */
+#define BE_F_TRANSC     (1u <<  9)  /* sin, cos, exp2, log2 */
+#define BE_F_F16        (1u << 10)
+#define BE_F_F64        (1u << 11)
+#define BE_F_BF16       (1u << 12)
+#define BE_F_MULTIOUT   (1u << 13)  /* emits multiple files (Tensix) */
+
+/* ---- Backend descriptor ----
+ * Every backend defines one of these. Static const, lives in the
+ * backend's own .c file, registered in src/backend/backends.c.
+ *
+ * Ops in pipeline order. NULL means "not applicable, driver skips":
+ *   isel     - required. Consumes BIR, produces backend module.
+ *   sched    - optional. Reorders instructions.
+ *   regalloc - optional. Assigns physical regs.
+ *   verify   - optional. Called at each defined phase.
+ *   emit     - required. Writes final output(s) to disk.
+ *   free_mmod- required if isel allocates.
+ *
+ * cfg is Booth's driver config; backends cast to be_cfg_t and pull
+ * the knobs they care about. Opaque here on purpose so the contract
+ * does not couple to driver internals. */
+typedef struct be_desc {
+    const char *name;              /* stable id: "amdgpu", "nvptx", ... */
+    const char *triple;            /* "amdgcn--", "nvptx64--", or NULL */
+    uint32_t    feats;             /* BE_F_* bitmask */
+
+    /* True when this backend should run for this invocation. Cheap. */
+    int  (*is_on)(const struct be_cfg *cfg);
+
+    /* Pipeline. */
+    int  (*isel)   (const struct bir_module *M,
+                    const struct be_cfg *cfg,
+                    void **out_mmod);
+    int  (*sched)  (void *mmod);
+    int  (*regalc) (void *mmod);
+    int  (*verify) (const void *mmod, int phase);
+    int  (*emit)   (const void *mmod,
+                    const struct be_cfg *cfg,
+                    const char *out_path);
+    void (*mfree)  (void *mmod);
+} be_desc_t;
+
+/* ---- Registration ----
+ * Static NULL-terminated list, populated in backends.c. Adding a
+ * backend means one extern decl + one entry in the array. No init
+ * order surprises. */
+extern const be_desc_t * const be_list[];
+
+/* Find by name. Returns NULL if unknown. O(n) over ~10 entries. */
+const be_desc_t *be_find(const char *name);
+
+/* ---- Driver-side glue ----
+ * The loop that iterates registered backends, calls is_on on each,
+ * runs the pipeline for the actives. Returns first non-OK code, or
+ * OK if all actives succeeded. */
+int be_run(const struct bir_module *M, const struct be_cfg *cfg);
+
+#endif /* BOOTH_BE_H */

--- a/src/backend/backend_cfg.h
+++ b/src/backend/backend_cfg.h
@@ -1,0 +1,31 @@
+/* backend_cfg.h -- driver config shared with every backend descriptor.
+ *
+ * Backends' is_on/isel/emit callbacks receive a const be_cfg_t* so
+ * they can read the mode flags, target selectors, and output paths
+ * they care about. Kept in one place so main.c and every backend
+ * agree on the field layout.
+ *
+ * If your backend needs a new knob, add the field here, populate it
+ * in main.c's CLI parse, read it from your backend descriptor. */
+
+#ifndef BOOTH_BE_CFG_H
+#define BOOTH_BE_CFG_H
+
+#include "amdgpu.h"   /* amd_target_t */
+#include "intel.h"    /* intel_target_t */
+
+typedef struct be_cfg {
+    int             no_mem2reg, no_cfold, no_dce, no_sched, no_sroa;
+    int             mode_ir, mode_tdf, mode_tdf_fission;
+    int             mode_amdgpu, mode_amdgpu_bin;
+    int             mode_tensix, mode_nvidia, nv_bkhit;
+    int             mode_metal, mode_intel, mode_rv_elf, mode_cpu, mode_rv64;
+    amd_target_t    amd_target;
+    uint32_t        amd_elfm;
+    const char     *amd_chip;
+    int             snap_mode;
+    intel_target_t  intel_target;
+    const char     *output_file;
+} be_cfg_t;
+
+#endif /* BOOTH_BE_CFG_H */

--- a/src/backend/backends.c
+++ b/src/backend/backends.c
@@ -1,0 +1,160 @@
+/* backends.c -- registered backend list and dispatch loop.
+ *
+ * Ooooooh yeah, finally a way to not have to read literally all of
+ * the AMD backend to know how to work this thang. If you're adding
+ * a new one: extern-declare your descriptor below, add it to be_list,
+ * you're wired in.
+ *
+ * The list is static, NULL-terminated, and iterated in order.
+ * be_run walks it, asks each one "you on?", and runs the pipeline
+ * for the yeses. No dlopen, no plugin loading, no init-order
+ * surprises. JPL discipline: bounded, deterministic, auditable. */
+
+#include "backend.h"
+#include "backend_cfg.h"
+#include <stdio.h>
+#include <string.h>
+
+/* Bound the list walk. If we ever hit 64 registered backends the
+ * project has bigger conversations to have. */
+#define BE_MAX  64
+
+/* ---- Backend descriptors ----
+ * One extern per backend. Descriptor structs live in each backend's
+ * own <name>_be.c. Skeleton compiles in only in dev builds. */
+extern const be_desc_t be_amd;
+extern const be_desc_t be_ptx;
+extern const be_desc_t be_tsx;
+extern const be_desc_t be_rvcore;
+extern const be_desc_t be_x86;
+extern const be_desc_t be_rv64;
+extern const be_desc_t be_metal;
+extern const be_desc_t be_intel;
+
+#ifdef BOOTH_INCLUDE_SKELETON
+extern const be_desc_t be_skel;
+#endif
+
+/* ---- The list ----
+ * Order affects driver output ordering only (which backend message
+ * shows first). Work is independent per backend. */
+const be_desc_t * const be_list[] = {
+    &be_amd,
+    &be_ptx,
+    &be_tsx,
+    &be_rvcore,
+    &be_metal,
+    &be_intel,
+    &be_x86,
+    &be_rv64,
+#ifdef BOOTH_INCLUDE_SKELETON
+    &be_skel,
+#endif
+    NULL
+};
+
+/* ---- Lookup ---- */
+const be_desc_t *be_find(const char *name)
+{
+    if (name == NULL) return NULL;
+    for (uint32_t i = 0; be_list[i] != NULL && i < BE_MAX; i++) {
+        if (be_list[i]->name != NULL &&
+            strcmp(be_list[i]->name, name) == 0) {
+            return be_list[i];
+        }
+    }
+    return NULL;
+}
+
+/* ---- Dispatch ----
+ * Iterate registered backends, run the active ones through the
+ * pipeline. Returns first non-OK code seen; keeps going through
+ * later actives so a partial invocation still produces the outputs
+ * that were fine. */
+int be_run(const struct bir_module *M, const be_cfg_t *cfg)
+{
+    if (M == NULL || cfg == NULL) return BE_EINPUT;
+
+    int first = BE_OK;
+
+    for (uint32_t i = 0; be_list[i] != NULL && i < BE_MAX; i++) {
+        const be_desc_t *b = be_list[i];
+
+        /* Skip backends with no is_on or that say no. */
+        if (b->is_on == NULL) continue;
+        if (!b->is_on(cfg)) continue;
+
+        /* isel is required. If a registered backend has no isel it's
+         * a bug in the descriptor, not something we tolerate. */
+        if (b->isel == NULL) {
+            fprintf(stderr, "backend %s: no isel op registered\n", b->name);
+            if (first == BE_OK) first = BE_UNSUP;
+            continue;
+        }
+
+        void *mmod = NULL;
+        int rc = b->isel(M, cfg, &mmod);
+        if (rc != BE_OK) {
+            if (first == BE_OK) first = rc;
+            if (mmod != NULL && b->mfree != NULL) b->mfree(mmod);
+            continue;
+        }
+
+        /* Optional post-isel verify. */
+        if (b->verify != NULL) {
+            int v = b->verify(mmod, BE_VFY_ISEL);
+            if (v != BE_OK) {
+                if (first == BE_OK) first = v;
+                if (b->mfree != NULL) b->mfree(mmod);
+                continue;
+            }
+        }
+
+        /* Optional sched. Honour --no-sched. */
+        if (b->sched != NULL && !cfg->no_sched) {
+            int s = b->sched(mmod);
+            if (s != BE_OK) {
+                if (first == BE_OK) first = s;
+                if (b->mfree != NULL) b->mfree(mmod);
+                continue;
+            }
+        }
+
+        /* Optional regalloc. */
+        if (b->regalc != NULL) {
+            int r = b->regalc(mmod);
+            if (r != BE_OK) {
+                if (first == BE_OK) first = r;
+                if (b->mfree != NULL) b->mfree(mmod);
+                continue;
+            }
+        }
+
+        /* Post-RA verify. */
+        if (b->verify != NULL) {
+            int v = b->verify(mmod, BE_VFY_RA);
+            if (v != BE_OK) {
+                if (first == BE_OK) first = v;
+                if (b->mfree != NULL) b->mfree(mmod);
+                continue;
+            }
+        }
+
+        /* Emit. Required. */
+        if (b->emit == NULL) {
+            fprintf(stderr, "backend %s: no emit op registered\n", b->name);
+            if (first == BE_OK) first = BE_UNSUP;
+            if (b->mfree != NULL) b->mfree(mmod);
+            continue;
+        }
+
+        int e = b->emit(mmod, cfg, cfg->output_file);
+        if (e != BE_OK) {
+            if (first == BE_OK) first = e;
+        }
+
+        if (b->mfree != NULL) b->mfree(mmod);
+    }
+
+    return first;
+}

--- a/src/backend/skeleton/skeleton.c
+++ b/src/backend/skeleton/skeleton.c
@@ -1,0 +1,75 @@
+/* skeleton.c -- reference backend that does nothing.
+ *
+ * Hello human or LLM asked to clone this: you are in the right
+ * place. This backend is the copy-paste starting point for a new
+ * target. It compiles, registers, dispatches, and returns UNSUP
+ * for every op. Your job is to make the ops do real work, one at
+ * a time, and flip the feature flags on as you go.
+ *
+ * Recipe:
+ *   1. cp -r src/backend/skeleton src/backend/mygpu
+ *   2. grep -rl skeleton src/backend/mygpu | xargs sed -i s/skel/mygpu/g
+ *   3. In src/backend/backends.c, add the extern and list entry.
+ *   4. In the Makefile, add src/backend/mygpu/mygpu.c to SOURCES.
+ *   5. Fill in isel first. Then emit. Then everything else.
+ *   6. Run make backend-conformance BACKEND=mygpu (Phase B, coming).
+ *
+ * Only compiled when -DBOOTH_INCLUDE_SKELETON is set, so release
+ * builds do not ship the empty backend.
+ *
+ * Zane was here 2026. */
+
+#ifdef BOOTH_INCLUDE_SKELETON
+
+#include "backend.h"
+#include "backend_cfg.h"
+
+/* is_on: gated on --skeleton flag which does not exist. Wire up a
+ * mode_skel field in be_cfg_t if you want to invoke this via the
+ * CLI. For a real backend, key off your own mode_* flag. */
+static int skel_on(const be_cfg_t *cfg)
+{
+    (void)cfg;
+    return 0;
+}
+
+/* isel: consume BIR, produce a backend module. Returning UNSUP makes
+ * the driver bail cleanly. Your first real work goes here. */
+static int skel_isel(const struct bir_module *M,
+                     const be_cfg_t *cfg,
+                     void **out_mmod)
+{
+    (void)M; (void)cfg; (void)out_mmod;
+    return BE_UNSUP;
+}
+
+/* emit: write bytes to disk. Required. */
+static int skel_emit(const void *mmod,
+                     const be_cfg_t *cfg,
+                     const char *out_path)
+{
+    (void)mmod; (void)cfg; (void)out_path;
+    return BE_UNSUP;
+}
+
+/* mfree: only needed if isel allocates. Skeleton does not. */
+static void skel_free(void *mmod)
+{
+    (void)mmod;
+}
+
+/* The descriptor. This is the shape every backend fills in. */
+const be_desc_t be_skel = {
+    .name    = "skeleton",
+    .triple  = NULL,
+    .feats   = 0,           /* declare features as you implement them */
+    .is_on   = skel_on,
+    .isel    = skel_isel,
+    .sched   = NULL,        /* optional */
+    .regalc  = NULL,        /* optional */
+    .verify  = NULL,        /* optional */
+    .emit    = skel_emit,
+    .mfree   = skel_free
+};
+
+#endif /* BOOTH_INCLUDE_SKELETON */

--- a/src/cpu/cpu_be.c
+++ b/src/cpu/cpu_be.c
@@ -1,0 +1,121 @@
+/* cpu_be.c -- x86-64 and RV64 CPU targets as be_desc_t descriptors.
+ *
+ * Two descriptors in one file because they share the shape: init,
+ * emit, elf write. No isel or regalloc phase; the emitter is
+ * stack-everything. */
+
+#include "backend.h"
+#include "backend_cfg.h"
+#include "cpu.h"
+#include "rv64.h"
+#include "barracuda.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+/* ---- x86-64 ---- */
+
+static int x86_on(const be_cfg_t *cfg)
+{
+    return cfg->mode_cpu;
+}
+
+static int x86_isel(const struct bir_module *M,
+                    const be_cfg_t *cfg,
+                    void **out_mmod)
+{
+    (void)cfg;
+    const bir_module_t *bir = (const bir_module_t *)M;
+    if (bir->num_funcs == 0u) {
+        fprintf(stderr, "error: no functions\n");
+        return BE_EINPUT;
+    }
+    cpu_mod_t *cm = (cpu_mod_t *)calloc(1, sizeof(cpu_mod_t));
+    if (cm == NULL) return BE_ENOMEM;
+    cpu_init(cm, bir);
+    if (cpu_emit(cm) != 0) { free(cm); return BE_EISEL; }
+    *out_mmod = cm;
+    return BE_OK;
+}
+
+static int x86_emit_op(const void *mmod, const be_cfg_t *cfg,
+                       const char *out_path)
+{
+    (void)cfg;
+    const cpu_mod_t *cm = (const cpu_mod_t *)mmod;
+    const char *p = out_path ? out_path : "a.o";
+    if (cpu_elf(cm, p) != 0) {
+        fprintf(stderr, "cpu: elf write failed\n");
+        return BE_EIO;
+    }
+    fprintf(stderr, "wrote %s (%u bytes x86-64)\n", p, cm->codelen);
+    return BE_OK;
+}
+
+static void x86_free(void *mmod) { free(mmod); }
+
+const be_desc_t be_x86 = {
+    .name    = "cpu-x86-64",
+    .triple  = "x86_64-unknown-none",
+    .feats   = BE_F_SCALAR | BE_F_TRANSC | BE_F_F64,
+    .is_on   = x86_on,
+    .isel    = x86_isel,
+    .sched   = NULL,
+    .regalc  = NULL,
+    .verify  = NULL,
+    .emit    = x86_emit_op,
+    .mfree   = x86_free
+};
+
+/* ---- RV64 ---- */
+
+static int rv64_on(const be_cfg_t *cfg)
+{
+    return cfg->mode_rv64;
+}
+
+static int rv64_isel(const struct bir_module *M,
+                     const be_cfg_t *cfg,
+                     void **out_mmod)
+{
+    (void)cfg;
+    const bir_module_t *bir = (const bir_module_t *)M;
+    if (bir->num_funcs == 0u) {
+        fprintf(stderr, "error: no functions\n");
+        return BE_EINPUT;
+    }
+    rv64_mod_t *vm = (rv64_mod_t *)calloc(1, sizeof(rv64_mod_t));
+    if (vm == NULL) return BE_ENOMEM;
+    rv64_init(vm, bir);
+    if (rv64_emit(vm) != 0) { free(vm); return BE_EISEL; }
+    *out_mmod = vm;
+    return BE_OK;
+}
+
+static int rv64_emit_op(const void *mmod, const be_cfg_t *cfg,
+                        const char *out_path)
+{
+    (void)cfg;
+    const rv64_mod_t *vm = (const rv64_mod_t *)mmod;
+    const char *p = out_path ? out_path : "a.o";
+    if (rv64_elf(vm, p) != 0) {
+        fprintf(stderr, "rv64: elf write failed\n");
+        return BE_EIO;
+    }
+    fprintf(stderr, "wrote %s (%u bytes RV64)\n", p, vm->codelen);
+    return BE_OK;
+}
+
+static void rv64_free(void *mmod) { free(mmod); }
+
+const be_desc_t be_rv64 = {
+    .name    = "cpu-rv64",
+    .triple  = "riscv64-unknown-none",
+    .feats   = BE_F_SCALAR | BE_F_TRANSC | BE_F_F64,
+    .is_on   = rv64_on,
+    .isel    = rv64_isel,
+    .sched   = NULL,
+    .regalc  = NULL,
+    .verify  = NULL,
+    .emit    = rv64_emit_op,
+    .mfree   = rv64_free
+};

--- a/src/intel/intel_be.c
+++ b/src/intel/intel_be.c
@@ -1,0 +1,54 @@
+/* intel_be.c -- Intel Arc SPIR-V as a be_desc_t. Stub-level today. */
+
+#include "backend.h"
+#include "backend_cfg.h"
+#include "intel.h"
+#include "barracuda.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+static int intel_on(const be_cfg_t *cfg)
+{
+    return cfg->mode_intel;
+}
+
+static int intel_isel(const struct bir_module *M,
+                      const be_cfg_t *cfg,
+                      void **out_mmod)
+{
+    intel_module_t *im = (intel_module_t *)calloc(1, sizeof(intel_module_t));
+    if (im == NULL) return BE_ENOMEM;
+    int rc = intel_compile((const bir_module_t *)M, im, cfg->intel_target);
+    if (rc != BC_OK) {
+        fprintf(stderr,
+            "error: Intel SPIR-V backend not yet a working compiler\n");
+        free(im);
+        return BE_EISEL;
+    }
+    *out_mmod = im;
+    return BE_OK;
+}
+
+static int intel_emit_op(const void *mmod, const be_cfg_t *cfg,
+                         const char *out_path)
+{
+    (void)cfg;
+    const char *p = out_path ? out_path : "a.spv";
+    int rc = intel_emit_spirv((const intel_module_t *)mmod, p);
+    return (rc == BC_OK) ? BE_OK : BE_EEMIT;
+}
+
+static void intel_free(void *mmod) { free(mmod); }
+
+const be_desc_t be_intel = {
+    .name    = "intel-spirv",
+    .triple  = NULL,
+    .feats   = BE_F_SIMT | BE_F_SHARED | BE_F_BARRIER,
+    .is_on   = intel_on,
+    .isel    = intel_isel,
+    .sched   = NULL,
+    .regalc  = NULL,
+    .verify  = NULL,
+    .emit    = intel_emit_op,
+    .mfree   = intel_free
+};

--- a/src/main.c
+++ b/src/main.c
@@ -23,6 +23,8 @@
 #include "rv_isel.h"
 #include "cpu.h"
 #include "rv64.h"
+#include "backend.h"
+#include "backend_cfg.h"
 #include <stdlib.h>
 
 static char       source_buf[BC_MAX_SOURCE];
@@ -38,19 +40,11 @@ static bir_module_t *bir_module; /* heap-allocated (~11 MB) */
  * path can both call it without duplicating two hundred lines of
  * backend wiring. */
 
-typedef struct {
-    int             no_mem2reg, no_cfold, no_dce, no_sched, no_sroa;
-    int             mode_ir, mode_tdf, mode_tdf_fission;
-    int             mode_amdgpu, mode_amdgpu_bin;
-    int             mode_tensix, mode_nvidia, nv_bkhit;
-    int             mode_metal, mode_intel, mode_rv_elf, mode_cpu, mode_rv64;
-    amd_target_t    amd_target;
-    uint32_t        amd_elfm;
-    const char     *amd_chip;
-    int             snap_mode;
-    intel_target_t  intel_target;
-    const char     *output_file;
-} backend_cfg_t;
+/* be_cfg_t definition lives in src/backend/backend_cfg.h so every
+ * backend descriptor sees the same field layout. Alias kept for the
+ * few local uses below that predate the move; new code should use
+ * be_cfg_t directly. */
+typedef be_cfg_t backend_cfg_t;
 
 /* TDF module and lowering scratch live in BSS, not on the stack.
  * The struct is ~20 KB and trips -Wstack-usage hard if you put it
@@ -164,210 +158,12 @@ static int run_bir_backends(bir_module_t *bir, const backend_cfg_t *cfg)
                bir->num_funcs, bir->num_globals, bir->num_insts);
     }
 
-    if (cfg->mode_amdgpu || cfg->mode_amdgpu_bin) {
-        amd_module_t *amd = (amd_module_t *)malloc(sizeof(amd_module_t));
-        if (!amd) {
-            fprintf(stderr, "error: failed to allocate AMD module\n");
-            return BC_ERR_IO;
-        }
-        amd->target = cfg->amd_target;
-        amd->elf_mach = cfg->amd_elfm;
-        amd->snap_mode = (uint8_t)cfg->snap_mode;
-        snprintf(amd->chip_name, sizeof(amd->chip_name), "%s", cfg->amd_chip);
-        int arc = amdgpu_compile(bir, amd);
-        if (arc == BC_OK) {
-            vfy_res_t v1 = bc_vfy(amd, VFY_ISEL);
-            if (v1.errs) {
-                fprintf(stderr, "verify: %u error(s) after isel\n", v1.errs);
-                arc = BC_ERR_VERIFY;
-            }
-        }
-        if (arc == BC_OK) {
-            if (!cfg->no_sched) amdgpu_sched(amd);
-            amdgpu_regalloc(amd);
-            vfy_res_t v2 = bc_vfy(amd, VFY_RA);
-            if (v2.errs) {
-                fprintf(stderr, "verify: %u error(s) after regalloc\n", v2.errs);
-                arc = BC_ERR_VERIFY;
-            }
-        }
-        if (arc == BC_OK) {
-            if (cfg->mode_amdgpu_bin)
-                amdgpu_emit_elf(amd,
-                    cfg->output_file ? cfg->output_file : "a.hsaco");
-            else
-                amdgpu_emit_asm(amd, stdout);
-        } else {
-            if (arc != BC_ERR_VERIFY)
-                fprintf(stderr, "error: AMDGPU compilation failed\n");
-            rc = arc;
-        }
-        free(amd);
-    }
-
-    if (cfg->mode_nvidia) {
-        nv_module_t *nvm = (nv_module_t *)malloc(sizeof(nv_module_t));
-        if (!nvm) {
-            fprintf(stderr, "error: failed to allocate NVIDIA module\n");
-            return BC_ERR_IO;
-        }
-        int nrc = nv_compile(bir, nvm);
-        if (nrc == BC_OK) {
-            nvm->bkhit = (uint8_t)cfg->nv_bkhit;
-            nv_emit_ptx(nvm, cfg->output_file ? cfg->output_file : "a.ptx");
-        } else {
-            fprintf(stderr, "error: NVIDIA PTX compilation failed\n");
-            rc = nrc;
-        }
-        free(nvm);
-    }
-
-    if (cfg->mode_metal) {
-        metal_module_t *mm = (metal_module_t *)malloc(sizeof(metal_module_t));
-        if (!mm) {
-            fprintf(stderr, "error: failed to allocate Metal module\n");
-            return BC_ERR_IO;
-        }
-        int mrc = metal_compile(bir, mm);
-        if (mrc == BC_OK) {
-            metal_emit_msl(mm, cfg->output_file ? cfg->output_file : "a.metal");
-        } else {
-            fprintf(stderr, "error: Metal backend compilation failed\n");
-            rc = mrc;
-        }
-        free(mm);
-    }
-
-    if (cfg->mode_intel) {
-        intel_module_t *im = (intel_module_t *)malloc(sizeof(intel_module_t));
-        if (!im) {
-            fprintf(stderr, "error: failed to allocate Intel module\n");
-            return BC_ERR_IO;
-        }
-        int irc = intel_compile(bir, im, cfg->intel_target);
-        if (irc == BC_OK) {
-            intel_emit_spirv(im, cfg->output_file ? cfg->output_file : "a.spv");
-        } else {
-            fprintf(stderr,
-                "error: Intel SPIR-V backend not yet a working compiler\n");
-            rc = irc;
-        }
-        free(im);
-    }
-
-    /* Native RV32IM emission for the baby cores. Picks the first
-     * function in the BIR module (which is the first CUDA kernel
-     * defined in the source) and runs it through the bring-up isel
-     * into an ELF that the tt-metal host loader can drop onto a
-     * baby core. Soft-float not yet linked in; integer kernels
-     * only for now. */
-    if (cfg->mode_cpu) {
-        static cpu_mod_t cm;
-        if (bir->num_funcs == 0u) { fprintf(stderr,"error: no functions\n"); return BC_ERR_TDF; }
-        cpu_init(&cm, bir);
-        cpu_emit(&cm);
-        const char *path = cfg->output_file ? cfg->output_file : "a.o";
-        if (cpu_elf(&cm, path) != 0) { fprintf(stderr,"cpu: elf write failed\n"); return BC_ERR_IO; }
-        fprintf(stderr, "wrote %s (%u bytes x86-64)\n", path, cm.codelen);
-    }
-
-    if (cfg->mode_rv64) {
-        static rv64_mod_t vm;
-        if (bir->num_funcs == 0u) { fprintf(stderr,"error: no functions\n"); return BC_ERR_TDF; }
-        rv64_init(&vm, bir);
-        rv64_emit(&vm);
-        const char *path = cfg->output_file ? cfg->output_file : "a.o";
-        if (rv64_elf(&vm, path) != 0) { fprintf(stderr,"rv64: elf write failed\n"); return BC_ERR_IO; }
-        fprintf(stderr, "wrote %s (%u bytes RV64)\n", path, vm.codelen);
-    }
-
-    if (cfg->mode_rv_elf) {
-        static rv_buf_t rv_code;
-        rv_buf_init(&rv_code);
-        if (bir->num_funcs == 0u) {
-            fprintf(stderr, "error: BIR module has no functions\n");
-            return BC_ERR_TDF;
-        }
-        /* Module, not just function 0: rv_isel_func records call patches but
-         * only rv_isel_module resolves them, so a BIR_CALL through this path
-         * would otherwise keep its placeholder and trap as an illegal insn. */
-        int irc = rv_isel_module(bir, &rv_code);
-        if (irc != BC_OK) return irc;
-        const char *path = cfg->output_file ? cfg->output_file : "a.elf";
-        int erc = rv_elf_write(&rv_code, path);
-        if (erc != BC_OK) return erc;
-        fprintf(stderr, "wrote %s (%u bytes code, %u instructions)\n",
-                path, rv_buf_nbytes(&rv_code),
-                rv_buf_n_words(&rv_code));
-    }
-
-    /* Tensix needs additional reader/writer/host emission besides
-     * the compute kernel, which is why it lives slightly off the
-     * shared shape. */
-    if (cfg->mode_tensix) {
-        tt_module_t *ttm = (tt_module_t *)malloc(sizeof(tt_module_t));
-        if (!ttm) {
-            fprintf(stderr, "error: failed to allocate Tensix module\n");
-            return BC_ERR_IO;
-        }
-        int trc = tensix_compile(bir, ttm);
-        if (trc == BC_OK) {
-            tensix_coarsen(ttm);
-            tensix_regalloc(ttm);
-            const char *compute_path =
-                cfg->output_file ? cfg->output_file : "a_compute.cpp";
-            tensix_analyze_datamov(bir, ttm, &ttm->dmov);
-            tensix_emit_metalium(ttm, compute_path);
-            /* Raw Tensix machine code alongside the Metalium C++: the encoded
-             * 32-bit word stream, decodable by ttas/Kahu. */
-            {
-                char bin_path[BC_MAX_PATH];
-                const char *st2 = strstr(compute_path, "_compute");
-                int bp = st2 ? (int)(st2 - compute_path)
-                             : (int)strlen(compute_path);
-                snprintf(bin_path, sizeof(bin_path), "%.*s_compute.bin",
-                         bp, compute_path);
-                tensix_emit_binary(ttm, bin_path);
-                /* The math core's RISC-V .ttinsn stream that issues them. */
-                snprintf(bin_path, sizeof(bin_path), "%.*s_compute.ttinsn",
-                         bp, compute_path);
-                tensix_emit_ttinsn(ttm, bin_path);
-            }
-            char host_path[BC_MAX_PATH];
-            char reader_path[BC_MAX_PATH];
-            char writer_path[BC_MAX_PATH];
-            const char *stem = strstr(compute_path, "_compute");
-            int pfx;
-            if (stem) pfx = (int)(stem - compute_path);
-            else {
-                const char *dot = strrchr(compute_path, '.');
-                pfx = dot ? (int)(dot - compute_path)
-                          : (int)strlen(compute_path);
-            }
-            snprintf(host_path,   sizeof(host_path),
-                     "%.*s_host.cpp",   pfx, compute_path);
-            snprintf(reader_path, sizeof(reader_path),
-                     "%.*s_reader.cpp", pfx, compute_path);
-            snprintf(writer_path, sizeof(writer_path),
-                     "%.*s_writer.cpp", pfx, compute_path);
-            tensix_emit_reader(ttm, &ttm->dmov, reader_path);
-            tensix_emit_writer(ttm, &ttm->dmov, writer_path);
-            tensix_emit_host_full(ttm, &ttm->dmov, host_path,
-                                  reader_path, compute_path, writer_path);
-            /* The same three cores as baby-core machine code, one shared L1
-             * address map. The Metalium C++ above is the dev path; these ELFs
-             * are the toolchain-free path. */
-            {
-                char elf_stem[BC_MAX_PATH];
-                snprintf(elf_stem, sizeof(elf_stem), "%.*s", pfx, compute_path);
-                tensix_emit_kernel_elves(ttm, &ttm->dmov, elf_stem);
-            }
-        } else {
-            fprintf(stderr, "error: Tensix compilation failed\n");
-            rc = trc;
-        }
-        free(ttm);
-    }
+    /* All backend dispatch flows through be_run. Each backend
+     * (amdgpu, nvptx, metal, intel, cpu-x86, cpu-rv64, tensix,
+     * tensix-rv32) is a be_desc_t in src/<name>/<name>_be.c and
+     * registered in src/backend/backends.c. See docs/backends.md. */
+    int brc = be_run((struct bir_module *)bir, (struct be_cfg *)cfg);
+    if (brc != BE_OK && rc == BC_OK) rc = BC_ERR_VERIFY;
 
     return rc;
 }

--- a/src/metal/metal_be.c
+++ b/src/metal/metal_be.c
@@ -1,0 +1,50 @@
+/* metal_be.c -- Apple Metal as a be_desc_t. Stub-level today. */
+
+#include "backend.h"
+#include "backend_cfg.h"
+#include "metal.h"
+#include "barracuda.h"
+#include <stdlib.h>
+
+static int metal_on(const be_cfg_t *cfg)
+{
+    return cfg->mode_metal;
+}
+
+static int metal_isel(const struct bir_module *M,
+                      const be_cfg_t *cfg,
+                      void **out_mmod)
+{
+    (void)cfg;
+    metal_module_t *mm = (metal_module_t *)calloc(1, sizeof(metal_module_t));
+    if (mm == NULL) return BE_ENOMEM;
+    int rc = metal_compile((const bir_module_t *)M, mm);
+    if (rc != BC_OK) { free(mm); return BE_EISEL; }
+    *out_mmod = mm;
+    return BE_OK;
+}
+
+static int metal_emit_op(const void *mmod, const be_cfg_t *cfg,
+                         const char *out_path)
+{
+    (void)cfg;
+    const char *p = out_path ? out_path : "a.metal";
+    int rc = metal_emit_msl((metal_module_t *)mmod, p);
+    return (rc == BC_OK) ? BE_OK : BE_EEMIT;
+}
+
+static void metal_free(void *mmod) { free(mmod); }
+
+const be_desc_t be_metal = {
+    .name    = "metal",
+    .triple  = NULL,
+    .feats   = BE_F_SIMT | BE_F_SHARED | BE_F_BARRIER | BE_F_TRANSC
+             | BE_F_F16 | BE_F_F64,
+    .is_on   = metal_on,
+    .isel    = metal_isel,
+    .sched   = NULL,
+    .regalc  = NULL,
+    .verify  = NULL,
+    .emit    = metal_emit_op,
+    .mfree   = metal_free
+};

--- a/src/nvidia/nv_be.c
+++ b/src/nvidia/nv_be.c
@@ -1,0 +1,51 @@
+/* nv_be.c -- NVIDIA PTX as a be_desc_t. */
+
+#include "backend.h"
+#include "backend_cfg.h"
+#include "nvidia.h"
+#include "barracuda.h"
+#include <stdlib.h>
+
+static int nv_on(const be_cfg_t *cfg)
+{
+    return cfg->mode_nvidia;
+}
+
+static int nv_isel(const struct bir_module *M,
+                   const be_cfg_t *cfg,
+                   void **out_mmod)
+{
+    nv_module_t *nvm = (nv_module_t *)calloc(1, sizeof(nv_module_t));
+    if (nvm == NULL) return BE_ENOMEM;
+    int rc = nv_compile((const bir_module_t *)M, nvm);
+    if (rc != BC_OK) { free(nvm); return BE_EISEL; }
+    nvm->bkhit = (uint8_t)cfg->nv_bkhit;
+    *out_mmod = nvm;
+    return BE_OK;
+}
+
+static int nv_emit_op(const void *mmod, const be_cfg_t *cfg,
+                      const char *out_path)
+{
+    const char *p = out_path ? out_path : "a.ptx";
+    (void)cfg;
+    int rc = nv_emit_ptx((nv_module_t *)mmod, p);
+    return (rc == BC_OK) ? BE_OK : BE_EEMIT;
+}
+
+static void nv_free(void *mmod) { free(mmod); }
+
+const be_desc_t be_ptx = {
+    .name    = "nvptx",
+    .triple  = "nvptx64--",
+    .feats   = BE_F_SIMT | BE_F_ATOMIC | BE_F_SHARED | BE_F_WARP
+             | BE_F_BARRIER | BE_F_DIV | BE_F_SCRATCH | BE_F_TRANSC
+             | BE_F_F16 | BE_F_F64 | BE_F_BF16,
+    .is_on   = nv_on,
+    .isel    = nv_isel,
+    .sched   = NULL,
+    .regalc  = NULL,
+    .verify  = NULL,
+    .emit    = nv_emit_op,
+    .mfree   = nv_free
+};

--- a/src/tensix/tensix_be.c
+++ b/src/tensix/tensix_be.c
@@ -1,0 +1,189 @@
+/* tensix_be.c -- Tensix Metalium and RV32 baby-core as be_desc_t.
+ *
+ * Two descriptors for the two Tensix personalities:
+ *   be_tsx    = --tensix, Metalium C++ compute + reader + writer + host
+ *   be_rvcore = --rv-elf, native RV32IM machine code for baby cores
+ *
+ * The Metalium path emits a small forest of files; the multi-output
+ * dance stays inside tt_emit, driver only asks for one op. */
+
+#include "backend.h"
+#include "backend_cfg.h"
+#include "tensix.h"
+#include "rv_isel.h"
+#include "rv_elf.h"
+#include "rv_buf.h"
+#include "barracuda.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* ---- Metalium / Tensix Tensix ----
+ * Stashes the BIR pointer alongside tt_module_t so emit doesn't
+ * need it re-plumbed through the driver. datamov analysis happens
+ * inside isel while the BIR is still in hand. */
+
+typedef struct {
+    tt_module_t          *tt;
+    const bir_module_t   *bir;
+} tt_wrap_t;
+
+static int tt_on(const be_cfg_t *cfg)
+{
+    return cfg->mode_tensix;
+}
+
+static int tt_isel(const struct bir_module *M,
+                   const be_cfg_t *cfg,
+                   void **out_mmod)
+{
+    (void)cfg;
+    tt_wrap_t *w = (tt_wrap_t *)calloc(1, sizeof(tt_wrap_t));
+    if (w == NULL) return BE_ENOMEM;
+    w->tt = (tt_module_t *)calloc(1, sizeof(tt_module_t));
+    if (w->tt == NULL) { free(w); return BE_ENOMEM; }
+    w->bir = (const bir_module_t *)M;
+
+    int rc = tensix_compile(w->bir, w->tt);
+    if (rc != BC_OK) {
+        fprintf(stderr, "error: Tensix compilation failed\n");
+        free(w->tt); free(w);
+        return BE_EISEL;
+    }
+    tensix_coarsen(w->tt);
+    tensix_regalloc(w->tt);
+    tensix_analyze_datamov(w->bir, w->tt, &w->tt->dmov);
+    *out_mmod = w;
+    return BE_OK;
+}
+
+static int tt_emit(const void *mmod, const be_cfg_t *cfg,
+                   const char *out_path)
+{
+    (void)cfg;
+    const tt_wrap_t *w = (const tt_wrap_t *)mmod;
+    tt_module_t *ttm = w->tt;
+    const char *compute_path = out_path ? out_path : "a_compute.cpp";
+
+    tensix_emit_metalium(ttm, compute_path);
+
+    /* Sibling paths derived from compute stem (strip _compute or .ext). */
+    char bin_path[BC_MAX_PATH];
+    const char *st2 = strstr(compute_path, "_compute");
+    int bp = st2 ? (int)(st2 - compute_path) : (int)strlen(compute_path);
+
+    snprintf(bin_path, sizeof(bin_path), "%.*s_compute.bin",
+             bp, compute_path);
+    tensix_emit_binary(ttm, bin_path);
+    snprintf(bin_path, sizeof(bin_path), "%.*s_compute.ttinsn",
+             bp, compute_path);
+    tensix_emit_ttinsn(ttm, bin_path);
+
+    char host_path[BC_MAX_PATH];
+    char reader_path[BC_MAX_PATH];
+    char writer_path[BC_MAX_PATH];
+    const char *stem = strstr(compute_path, "_compute");
+    int pfx;
+    if (stem) pfx = (int)(stem - compute_path);
+    else {
+        const char *dot = strrchr(compute_path, '.');
+        pfx = dot ? (int)(dot - compute_path)
+                  : (int)strlen(compute_path);
+    }
+    snprintf(host_path,   sizeof(host_path),
+             "%.*s_host.cpp",   pfx, compute_path);
+    snprintf(reader_path, sizeof(reader_path),
+             "%.*s_reader.cpp", pfx, compute_path);
+    snprintf(writer_path, sizeof(writer_path),
+             "%.*s_writer.cpp", pfx, compute_path);
+    tensix_emit_reader(ttm, &ttm->dmov, reader_path);
+    tensix_emit_writer(ttm, &ttm->dmov, writer_path);
+    tensix_emit_host_full(ttm, &ttm->dmov, host_path,
+                          reader_path, compute_path, writer_path);
+
+    /* ELF drop for the toolchain-free path. */
+    {
+        char elf_stem[BC_MAX_PATH];
+        snprintf(elf_stem, sizeof(elf_stem), "%.*s", pfx, compute_path);
+        tensix_emit_kernel_elves(ttm, &ttm->dmov, elf_stem);
+    }
+    return BE_OK;
+}
+
+static void tt_free(void *mmod)
+{
+    tt_wrap_t *w = (tt_wrap_t *)mmod;
+    if (w == NULL) return;
+    free(w->tt);
+    free(w);
+}
+
+const be_desc_t be_tsx = {
+    .name    = "tensix",
+    .triple  = NULL,
+    .feats   = BE_F_SIMT | BE_F_SHARED | BE_F_BARRIER | BE_F_MFMA
+             | BE_F_MULTIOUT | BE_F_F16 | BE_F_BF16,
+    .is_on   = tt_on,
+    .isel    = tt_isel,
+    .sched   = NULL,
+    .regalc  = NULL,
+    .verify  = NULL,
+    .emit    = tt_emit,
+    .mfree   = tt_free
+};
+
+/* ---- Tensix baby-core RV32IM ----
+ * Different pipeline entirely: BIR to raw RV32IM instructions in an
+ * rv_buf_t, then straight to ELF. */
+
+static int rv_on(const be_cfg_t *cfg)
+{
+    return cfg->mode_rv_elf;
+}
+
+static int rv_isel(const struct bir_module *M,
+                   const be_cfg_t *cfg,
+                   void **out_mmod)
+{
+    (void)cfg;
+    const bir_module_t *bir = (const bir_module_t *)M;
+    if (bir->num_funcs == 0u) {
+        fprintf(stderr, "error: BIR module has no functions\n");
+        return BE_EINPUT;
+    }
+    rv_buf_t *code = (rv_buf_t *)calloc(1, sizeof(rv_buf_t));
+    if (code == NULL) return BE_ENOMEM;
+    rv_buf_init(code);
+    int rc = rv_isel_module(bir, code);
+    if (rc != BC_OK) { free(code); return BE_EISEL; }
+    *out_mmod = code;
+    return BE_OK;
+}
+
+static int rv_emit(const void *mmod, const be_cfg_t *cfg,
+                   const char *out_path)
+{
+    (void)cfg;
+    const rv_buf_t *code = (const rv_buf_t *)mmod;
+    const char *p = out_path ? out_path : "a.elf";
+    int rc = rv_elf_write(code, p);
+    if (rc != BC_OK) return BE_EIO;
+    fprintf(stderr, "wrote %s (%u bytes code, %u instructions)\n",
+            p, rv_buf_nbytes(code), rv_buf_n_words(code));
+    return BE_OK;
+}
+
+static void rv_free(void *mmod) { free(mmod); }
+
+const be_desc_t be_rvcore = {
+    .name    = "tensix-rv32",
+    .triple  = "riscv32-unknown-none",
+    .feats   = BE_F_SCALAR,
+    .is_on   = rv_on,
+    .isel    = rv_isel,
+    .sched   = NULL,
+    .regalc  = NULL,
+    .verify  = NULL,
+    .emit    = rv_emit,
+    .mfree   = rv_free
+};

--- a/tests/tbackend.c
+++ b/tests/tbackend.c
@@ -1,0 +1,77 @@
+/* tbackend.c -- backend contract smoke tests.
+ *
+ * Every registered backend must have a name, an is_on, an isel, and
+ * an emit. Anything less and the descriptor is broken. Also checks
+ * be_find returns the right thing (and NULL for unknown). */
+
+#include "tharns.h"
+#include "backend.h"
+#include <string.h>
+
+/* ---- Every entry in the list has the required ops ---- */
+
+static void be_list_ok(void)
+{
+    uint32_t seen = 0;
+    for (uint32_t i = 0; be_list[i] != NULL && i < 64; i++) {
+        const be_desc_t *b = be_list[i];
+        CHECK(b->name != NULL);
+        CHECK(b->name[0] != '\0');
+        CHECK(b->is_on != NULL);
+        CHECK(b->isel  != NULL);
+        CHECK(b->emit  != NULL);
+        seen++;
+    }
+    /* Booth ships with eight first-class backends today; skeleton is
+     * a compile-time addition in dev builds. */
+    CHECK(seen >= 8);
+    PASS();
+}
+TH_REG("backend", be_list_ok)
+
+/* ---- be_find finds every registered name and NULL for unknown ---- */
+
+static void be_find_hits(void)
+{
+    static const char * const known[] = {
+        "amdgpu", "nvptx", "tensix", "tensix-rv32",
+        "metal", "intel-spirv", "cpu-x86-64", "cpu-rv64"
+    };
+    for (uint32_t i = 0; i < sizeof(known)/sizeof(known[0]); i++) {
+        const be_desc_t *b = be_find(known[i]);
+        CHECK(b != NULL);
+        CHSTR(b->name, known[i]);
+    }
+    PASS();
+}
+TH_REG("backend", be_find_hits)
+
+static void be_find_miss(void)
+{
+    CHECK(be_find(NULL) == NULL);
+    CHECK(be_find("") == NULL);
+    CHECK(be_find("this-is-not-a-real-backend") == NULL);
+    PASS();
+}
+TH_REG("backend", be_find_miss)
+
+/* ---- Features declared match the descriptor invariants.
+ * If BE_F_MFMA is set the backend claims matrix ops; the conformance
+ * suite (coming in Phase B) will actually test that. For now just
+ * assert the flags are in the valid range. */
+
+static void be_feats_sane(void)
+{
+    const uint32_t all_valid =
+        BE_F_SIMT | BE_F_SCALAR | BE_F_ATOMIC | BE_F_SHARED |
+        BE_F_WARP | BE_F_MFMA | BE_F_BARRIER | BE_F_DIV |
+        BE_F_SCRATCH | BE_F_TRANSC | BE_F_F16 | BE_F_F64 |
+        BE_F_BF16 | BE_F_MULTIOUT;
+    for (uint32_t i = 0; be_list[i] != NULL && i < 64; i++) {
+        const be_desc_t *b = be_list[i];
+        uint32_t stray = b->feats & ~all_valid;
+        CHEQ(stray, 0u);
+    }
+    PASS();
+}
+TH_REG("backend", be_feats_sane)


### PR DESCRIPTION
Adds `src/backend/backend.h` defining `be_desc_t` (is_on, isel, sched, regalloc, verify, emit, mfree) plus `BE_F_*` feature flags. Every existing backend now sits behind a descriptor in its own `<name>_be.c`; the driver iterates a static `be_list` instead of the copy-pasted if-chain in main.c (200 lines gone).

Skeleton in `src/backend/skeleton/` is the copy-paste starting point for a new target, compiled only under `BOOTH_INCLUDE_SKELETON` so release builds don't ship the empty backend. `docs/backends.md` walks the pipeline, contract, feature flags, and reference backends by shape.

AMDGPU sysprint reproducer verified end-to-end against the new dispatch: same output as before (424 bytes hsaco, same verifier warnings). Test suite: 352/12/1 with 4 new `be_*` smoke tests, no regressions.

Phase A of the backend authoring plan. Phase B (conformance suite) and Phase C (`src/be_common/` shared substrate) are next but independent.